### PR TITLE
Add missing text for partial immunization (EXPOSUREAPP-11739)

### DIFF
--- a/lib/ccl/functions/getDccWalletInfo.js
+++ b/lib/ccl/functions/getDccWalletInfo.js
@@ -225,15 +225,34 @@ const descriptor = {
             assign: [
               'vaccinationState.longText',
               {
-                init: [
-                  'object',
-                  'type', 'system-time-dependent',
-                  'functionName', 'getVaccinationStateLongText',
-                  'parameters', {
+                if: [
+                  {
+                    '!==': [
+                      { var: 'walletAnalysis.vaccinationState' },
+                      'PARTIAL_IMMUNIZATION'
+                    ]
+                  },
+                  {
                     init: [
                       'object',
-                      'dt', { var: 'walletAnalysis.mostRecentVaccinationCertificate.hcert.v.0.dt' },
-                      'offsetInDays', { var: 'walletAnalysis.mostRecentVaccinationCertificate.__offsetInDays' }
+                      'type', 'system-time-dependent',
+                      'functionName', 'getVaccinationStateLongText',
+                      'parameters', {
+                        init: [
+                          'object',
+                          'dt', { var: 'walletAnalysis.mostRecentVaccinationCertificate.hcert.v.0.dt' },
+                          'offsetInDays', { var: 'walletAnalysis.mostRecentVaccinationCertificate.__offsetInDays' }
+                        ]
+                      }
+                    ]
+                  },
+                  // else
+                  {
+                    call: [
+                      '__i18n.getTextDescriptor',
+                      {
+                        key: 'VACCINATION_STATE_PARTIAL_IMMUNIZATION_LONG_TEXT'
+                      }
                     ]
                   }
                 ]

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -71,7 +71,7 @@
     <item quantity="many">"Letzte Impfung vor %1$d Tagen"</item>
     <item quantity="other">"Letzte Impfung vor %1$d Tagen"</item>
   </plurals>
-  <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION_PENDING Card Subtitle -->
+  <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION_PENDING Card Long Text -->
   <plurals name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_PENDING_LONG_TEXT">
     <item quantity="zero">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst in %1$d Tagen vollständig.</item>
     <item quantity="one">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst in %1$d Tag vollständig.</item>
@@ -80,8 +80,10 @@
     <item quantity="many">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst in %1$d Tagen vollständig.</item>
     <item quantity="other">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst in %1$d Tagen vollständig.</item>
   </plurals>
-  <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION Card Subtitle -->
+  <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION Card Long Text -->
   <string name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_LONG_TEXT">"Sie haben nun alle derzeit geplanten Impfungen erhalten. Ihr Impfschutz ist vollständig."</string>
+  <!-- XTXT: Vaccination State - PARTIAL_IMMUNIZATION Card Long Text -->
+  <string name="VACCINATION_STATE_PARTIAL_IMMUNIZATION_LONG_TEXT">"Sie haben noch nicht alle derzeit geplanten Impfungen erhalten. Daher ist Ihr Impfschutz noch nicht vollständig."</string>
   
   <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION Card Subtitle -->
   <string name="PERSON_VIEW_2G_CERTIFICATE">"2G-Zertifikat"</string>

--- a/test/fixtures/ccl/dcc-series-standard-vaccination.yaml
+++ b/test/fixtures/ccl/dcc-series-standard-vaccination.yaml
@@ -29,6 +29,18 @@
         hasBooster: false
         verificationCertificates:
           - certificate: biontech1/2
+        walletInfo:
+          admissionState:
+            visible: false
+          vaccinationState:
+            visible: true
+            titleText:
+              de: Impfstatus
+            subtitleText:
+              de: Letzte Impfung heute
+            longText:
+              de: noch nicht vollständig
+            faqAnchor: test
     # Complete vaccination not yet valid
     - time: biontech2/2
       assertions:


### PR DESCRIPTION
The PR adds the missing text for partial immunization and a corresponding test case.