### PR TITLE
Fix: don't show the same DCC twice on the Certificates Tab (EXPOSUREAPP-11823)

### DIFF
--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -1227,12 +1227,22 @@ const descriptor = {
       {
         if: [
           {
-            in: [
-              { var: 'admissionState' },
-              [
-                '1G_PLUS_PCR',
-                '2G_PLUS_PCR'
-              ]
+            and: [
+              {
+                in: [
+                  { var: 'admissionState' },
+                  [
+                    '1G_PLUS_PCR',
+                    '2G_PLUS_PCR'
+                  ]
+                ]
+              },
+              {
+                '!==': [
+                  { var: 'mostRelevantCertificate.barcodeData' },
+                  { var: 'allTCsWithValidPCR.0.barcodeData' }
+                ]
+              }
             ]
           },
           {
@@ -1251,12 +1261,22 @@ const descriptor = {
       {
         if: [
           {
-            in: [
-              { var: 'admissionState' },
-              [
-                '1G_PLUS_RAT',
-                '2G_PLUS_RAT'
-              ]
+            and: [
+              {
+                in: [
+                  { var: 'admissionState' },
+                  [
+                    '1G_PLUS_RAT',
+                    '2G_PLUS_RAT'
+                  ]
+                ]
+              },
+              {
+                '!==': [
+                  { var: 'mostRelevantCertificate.barcodeData' },
+                  { var: 'allTCsWithValidRAT.0.barcodeData' }
+                ]
+              }
             ]
           },
           {

--- a/test/fixtures/ccl/dcc-series-bug-reports.yaml
+++ b/test/fixtures/ccl/dcc-series-bug-reports.yaml
@@ -1,0 +1,42 @@
+- description: EXPOSUREAPP-11823 - RC + old 2/2 booster + TCs in the 14 days after 2/2
+  t0: '2022-02-14'
+  series:
+    - time: '2021-07-14'
+      rc: rc1
+    - time: +P200D # beyond rc validity
+      vc: astra2/2
+    - time: +P1D
+      tc: pcr1
+    - time: +P5D
+      tc: rat1
+  testCases:
+    - time: astra2/2
+      description: older booster notation and thus 2G; complete immunization but not prioritized for the next 15 days as indistinguishable
+      assertions:
+        admissionState: 2G
+        mostRelevantCertificate: astra2/2
+        vaccinationState: COMPLETE_IMMUNIZATION
+        verificationCertificates:
+          - certificate: astra2/2
+    - time: pcr1
+      description: PCR test gets priority while vaccination is prioritized
+      assertions:
+        admissionState: 2G_PLUS_PCR
+        mostRelevantCertificate: pcr1
+        verificationCertificates:
+          - certificate: pcr1
+    - time: rat1
+      description: RAT test gets priority while vaccination is prioritized
+      assertions:
+        admissionState: 2G_PLUS_RAT
+        mostRelevantCertificate: rat1
+        verificationCertificates:
+          - certificate: rat1
+    - time: astra2/2+P15D
+      description: vaccination gets priority after 15 days
+      assertions:
+        admissionState: 2G
+        mostRelevantCertificate: astra2/2
+        vaccinationState: COMPLETE_IMMUNIZATION
+        verificationCertificates:
+          - certificate: astra2/2


### PR DESCRIPTION
Adds logic to ensure that if we are in 2G+ and the TC is the most relevant DCC, that it's not displayed twice