### PR TITLE
Feat: change RC validity back to 90 days (EXPOSUREAPP-11873)

### DIFF
--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -101,12 +101,12 @@ const descriptor = {
                               {
                                 '<=': [
                                   { var: 'it.__ageInDays' },
-                                  180
+                                  90
                                 ]
                               }
                             ]
                           },
-                          // the date of the first test is >= 29 days and <= 180 days
+                          // the date of the first test is >= 29 days and <= 90 days
                           {
                             assign: [
                               'it.__isValid',

--- a/test/fixtures/ccl/dcc-series-recovery.yaml
+++ b/test/fixtures/ccl/dcc-series-recovery.yaml
@@ -81,20 +81,9 @@
         mostRecentVaccination: 
         hasBooster: false
         verificationCertificates:
-          - certificate: rc1
-    # recovery still valid after 180 days
-    - time: rc1+P180D
-      assertions:
-        admissionState: 2G
-        mostRelevantCertificate: rc1
-        vaccinationState: OTHER
-        vaccinationValidFrom: 
-        mostRecentVaccination: 
-        hasBooster: false
-        verificationCertificates:
-          - certificate: rc1
-    # recovery gets invalid after 181 days
-    - time: rc1+P181D
+          - certificate: rc1    
+    # recovery gets invalid after 91 days
+    - time: rc1+P91D
       assertions:
         admissionState: OTHER
         mostRelevantCertificate: rc1
@@ -103,7 +92,7 @@
         mostRecentVaccination: 
         hasBooster: false
         verificationCertificates:
-          - certificate: rc1
+          - certificate: rc1    
     # Complete vaccination immedeately valid after first vaccination
     - time: biontech1/1
       assertions:
@@ -325,17 +314,17 @@
         hasBooster: true
         verificationCertificates:
           - certificate: rc1
-    # recovery still valid after 180 days --> 1G
-    - time: rc1+P180D
+    # recovery still valid after 91 days, but vc is prioritized
+    - time: rc1+P91D
       assertions:
         admissionState: 1G
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: biontech2/2
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: biontech2/2+P15D
         mostRecentVaccination: biontech2/2
         hasBooster: true
         verificationCertificates:
-          - certificate: rc1
+          - certificate: biontech2/2
     # recovery still valid after 181 days, but vc is prioritized
     - time: rc1+P181D
       assertions:
@@ -480,19 +469,8 @@
         hasBooster: false
         verificationCertificates:
           - certificate: rc1
-    # recovery still valid after 180 days
-    - time: rc1+P180D
-      assertions:
-        admissionState: 2G
-        mostRelevantCertificate: rc1
-        vaccinationState: PARTIAL_IMMUNIZATION
-        vaccinationValidFrom: 
-        mostRecentVaccination: biontech1/2
-        hasBooster: false
-        verificationCertificates:
-          - certificate: rc1
-    # recovery not valid after 181 days
-    - time: rc1+P181D
+    # recovery not valid after 91 days
+    - time: rc1+P91D
       assertions:
         admissionState: OTHER
         mostRelevantCertificate: biontech1/2


### PR DESCRIPTION
Partial revert of https://github.com/corona-warn-app/cwa-app-ccl/pull/15