### PR TITLE
chore(i18n): clean up text keys (EXPOSUREAPP-11875)

### DIFF
--- a/resources/i18n/bg/strings.xml
+++ b/resources/i18n/bg/strings.xml
@@ -10,13 +10,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Вашите сертификати отговарят на 2G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ бърз тест"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"Вашите сертификати отговарят на 2G plus правилото, освен ако не Ви се изисква PCR тест. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/bg/strings.xml
+++ b/resources/i18n/bg/strings.xml
@@ -3,12 +3,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Доказателство за статус"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ PCR тест"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Вашите сертификати отговарят на 2G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR тест"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Вашите сертификати отговарят на 2G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/bg/strings.xml
+++ b/resources/i18n/bg/strings.xml
@@ -5,29 +5,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR тест"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Вашите сертификати отговарят на 2G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Вашите сертификати отговарят на 2G правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Вашите сертификати отговарят на 3G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Вашите сертификати отговарят на 3G правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
 

--- a/resources/i18n/bg/strings.xml
+++ b/resources/i18n/bg/strings.xml
@@ -3,27 +3,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Доказателство за статус"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ PCR тест"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Вашите сертификати отговарят на 1G plus правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ бърз тест"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"Вашите сертификати отговарят на 1G plus правилото, освен ако не Ви се изисква PCR тест. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Вашите сертификати отговарят на 1G правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -6,29 +6,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR-Test"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Ihre Zertifikate erfüllen die 3G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Ihre Zertifikate erfüllen die 3G-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -4,27 +4,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Status-Nachweis"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ PCR-Test"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Ihre Zertifikate erfüllen die 1G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ Schnelltest"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"Ihre Zertifikate erfüllen die 1G-Plus-Regel, es sei denn, es wird ein PCR-Test benötigt. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Ihre Zertifikate erfüllen die 1G-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -4,12 +4,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Status-Nachweis"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ PCR-Test"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR-Test"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -11,13 +11,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Plus-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ Schnelltest"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"Ihre Zertifikate erfüllen die 2G-Plus-Regel, es sei denn, es wird ein PCR-Test benötigt. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/en/strings.xml
+++ b/resources/i18n/en/strings.xml
@@ -10,13 +10,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Your certificates satisfy the 2G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ rapid test"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"Your certificates satisfy the 2G plus rule, unless a PCR test is required. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/en/strings.xml
+++ b/resources/i18n/en/strings.xml
@@ -5,29 +5,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR test"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Your certificates satisfy the 2G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Your certificates satisfy the 2G rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Your certificates satisfy the 3G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Your certificates satisfy the 3G rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 

--- a/resources/i18n/en/strings.xml
+++ b/resources/i18n/en/strings.xml
@@ -3,27 +3,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Proof of Status"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ PCR test"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Your certificates satisfy the 1G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ rapid test"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"Your certificates satisfy the 1G plus rule, unless a PCR test is required. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Your certificates satisfy the 1G rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->

--- a/resources/i18n/en/strings.xml
+++ b/resources/i18n/en/strings.xml
@@ -3,12 +3,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Proof of Status"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ PCR test"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Your certificates satisfy the 2G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR test"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Your certificates satisfy the 2G plus rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/pl/strings.xml
+++ b/resources/i18n/pl/strings.xml
@@ -10,13 +10,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ szybki test"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G plus, o ile nie jest wymagany test PCR. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/pl/strings.xml
+++ b/resources/i18n/pl/strings.xml
@@ -3,12 +3,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Dowód statusu"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ test PCR"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ test PCR"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/pl/strings.xml
+++ b/resources/i18n/pl/strings.xml
@@ -5,29 +5,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ test PCR"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 2G. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 3G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i pokaż kod QR w przeglądzie certyfikatów."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 3G. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i pokaż kod QR w przeglądzie certyfikatów."</string>
 

--- a/resources/i18n/pl/strings.xml
+++ b/resources/i18n/pl/strings.xml
@@ -3,27 +3,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Dowód statusu"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ test PCR"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 1G plus. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i pokaż kod QR w przeglądzie certyfikatów."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ szybki test"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 1G plus, o ile nie jest wymagany test PCR. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Twoje certyfikaty są zgodne z zasadą 1G. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i pokaż kod QR w przeglądzie certyfikatów."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->

--- a/resources/i18n/ro/strings.xml
+++ b/resources/i18n/ro/strings.xml
@@ -10,13 +10,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Certificatele dvs. respectă regula 2G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ test rapid"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"Certificatele dvs. respectă regula 2G plus, cu excepția cazului în care este necesar un test PCR. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/ro/strings.xml
+++ b/resources/i18n/ro/strings.xml
@@ -3,27 +3,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Dovada stării"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ test PCR"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Certificatele dvs. respectă regula 1G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ test rapid"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"Certificatele dvs. respectă regula 1G plus, cu excepția cazului în care este necesar un test PCR. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Certificatele dvs. respectă regula 1G. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->

--- a/resources/i18n/ro/strings.xml
+++ b/resources/i18n/ro/strings.xml
@@ -5,29 +5,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ test PCR"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Certificatele dvs. respectă regula 2G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Certificatele dvs. respectă regula 2G. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Certificatele dvs. respectă regula 3G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Certificatele dvs. respectă regula 3G. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 

--- a/resources/i18n/ro/strings.xml
+++ b/resources/i18n/ro/strings.xml
@@ -3,12 +3,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Dovada stării"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ test PCR"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Certificatele dvs. respectă regula 2G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ test PCR"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Certificatele dvs. respectă regula 2G plus. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/tr/strings.xml
+++ b/resources/i18n/tr/strings.xml
@@ -5,29 +5,21 @@
 
   <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR testi"</string>
   <!-- XTXT: Admission State - 2G_PLUS Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
-  <!-- XTXT: Admission State - 2G Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_SUBTITLE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Body -->
   <string name="ADMISSION_STATE_2G_LONG_TEXT">"Sertifikalarınız 2G kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_PCR Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_BADGE_TEXT">"3G+"</string>
-  <!-- XTXT: Admission State - 3G_WITH_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_PCR_SUBTITLE_TEXT">"3G+"</string>
   <!-- XTXT: Admission State - 3G_WITH_PCR Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_PCR_LONG_TEXT">"Sertifikalarınız 3G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 
   <!-- XTXT: Admission State - 3G_WITH_RAT Badge Text -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_BADGE_TEXT">"3G"</string>
-  <!-- XTXT: Admission State - 3G_WITH_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_3G_WITH_RAT_SUBTITLE_TEXT">"3G"</string>
   <!-- XTXT: Admission State - 3G_WITH_RAT Card Body -->
   <string name="ADMISSION_STATE_3G_WITH_RAT_LONG_TEXT">"Sertifikalarınız 3G kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 

--- a/resources/i18n/tr/strings.xml
+++ b/resources/i18n/tr/strings.xml
@@ -3,12 +3,12 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Durum Kanıtı"</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_SUBTITLE_TEXT">"2G+ PCR testi"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
+  <!-- XTXT: Admission State - 2G_PLUS Badge Text -->
+  <string name="ADMISSION_STATE_2G_PLUS_BADGE_TEXT">"2G+"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Subtitle -->
+  <string name="ADMISSION_STATE_2G_PLUS_SUBTITLE_TEXT">"2G+ PCR testi"</string>
+  <!-- XTXT: Admission State - 2G_PLUS Card Body -->
+  <string name="ADMISSION_STATE_2G_PLUS_LONG_TEXT">"Sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>

--- a/resources/i18n/tr/strings.xml
+++ b/resources/i18n/tr/strings.xml
@@ -10,13 +10,6 @@
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Body -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_LONG_TEXT">"Sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
 
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_BADGE_TEXT">"2G+"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_SUBTITLE_TEXT">"2G+ hızlı testi"</string>
-  <!-- XTXT: Admission State - 2G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_2G_PLUS_RAT_LONG_TEXT">"PCR testi gerekmiyorsa sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
-
   <!-- XTXT: Admission State - 2G Badge Text -->
   <string name="ADMISSION_STATE_2G_BADGE_TEXT">"2G"</string>
   <!-- XTXT: Admission State - 2G Card Subtitle -->

--- a/resources/i18n/tr/strings.xml
+++ b/resources/i18n/tr/strings.xml
@@ -3,27 +3,6 @@
   <!-- XHED: Admission State - Card Title -->
   <string name="ADMISSION_STATE_TITLE_TEXT">"Durum Kanıtı"</string>
 
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_SUBTITLE_TEXT">"1G+ PCR testi"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_PCR Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_PCR_LONG_TEXT">"Sertifikalarınız 1G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
-
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Badge Text -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_BADGE_TEXT">"1G+"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_SUBTITLE_TEXT">"1G+ hızlı testi"</string>
-  <!-- XTXT: Admission State - 1G_PLUS_RAT Card Body -->
-  <string name="ADMISSION_STATE_1G_PLUS_RAT_LONG_TEXT">"PCR testi gerekmiyorsa sertifikalarınız 1G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
-
-  <!-- XTXT: Admission State - 1G Badge Text -->
-  <string name="ADMISSION_STATE_1G_BADGE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Subtitle -->
-  <string name="ADMISSION_STATE_1G_SUBTITLE_TEXT">"1G"</string>
-  <!-- XTXT: Admission State - 1G Card Body -->
-  <string name="ADMISSION_STATE_1G_LONG_TEXT">"Sertifikalarınız 1G kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
-
   <!-- XTXT: Admission State - 2G_PLUS_PCR Badge Text -->
   <string name="ADMISSION_STATE_2G_PLUS_PCR_BADGE_TEXT">"2G+"</string>
   <!-- XTXT: Admission State - 2G_PLUS_PCR Card Subtitle -->


### PR DESCRIPTION
This PR removes text keys that are not required any more and renames some of the identifiers. As the actual texts themselves don't change, this is done in all language files.