### PR TITLE
Feat: dummy-support for scenarioIdentifier (testing-only) (EXPOSUREAPP-11991)

### DIFF
--- a/lib/ccl/functions/getDccWalletInfo.js
+++ b/lib/ccl/functions/getDccWalletInfo.js
@@ -143,7 +143,21 @@ const descriptor = {
               'admissionState.subtitleText',
               {
                 if: [
-                  { var: 'hasScenarioIdentifier' },
+                  {
+                    and: [
+                      { var: 'hasScenarioIdentifier' },
+                      {
+                        in: [
+                          { var: 'scenarioIdentifier' },
+                          [
+                            'DE',
+                            'BW',
+                            'HH'
+                          ]
+                        ]
+                      }
+                    ]
+                  },
                   {
                     init: [
                       'object',

--- a/lib/ccl/functions/getDccWalletInfo.js
+++ b/lib/ccl/functions/getDccWalletInfo.js
@@ -16,9 +16,22 @@ const descriptor = {
       },
       {
         name: 'boosterNotificationRules'
+      },
+      {
+        name: 'scenarioIdentifier'
       }
     ],
     logic: [
+      {
+        declare: [
+          'hasScenarioIdentifier',
+          {
+            '!!': [
+              { var: 'scenarioIdentifier' }
+            ]
+          }
+        ]
+      },
       {
         declare: [
           'walletAnalysis',
@@ -128,7 +141,27 @@ const descriptor = {
           {
             assign: [
               'admissionState.subtitleText',
-              { var: 'admissionState.badgeText' }
+              {
+                if: [
+                  { var: 'hasScenarioIdentifier' },
+                  {
+                    init: [
+                      'object',
+                      'type', 'string',
+                      'localizedText', {
+                        init: [
+                          'object',
+                          'en', { var: 'scenarioIdentifier' },
+                          'de', { var: 'scenarioIdentifier' }
+                        ]
+                      },
+                      'parameters', []
+                    ]
+                  },
+                  // else
+                  { var: 'admissionState.badgeText' }
+                ]
+              }
             ]
           }
         ]

--- a/lib/ccl/functions/getDccWalletInfo.js
+++ b/lib/ccl/functions/getDccWalletInfo.js
@@ -34,6 +34,26 @@ const descriptor = {
       },
       {
         declare: [
+          'hasExistentScenarioIdentifier',
+          {
+            and: [
+              { var: 'hasScenarioIdentifier' },
+              {
+                in: [
+                  { var: 'scenarioIdentifier' },
+                  [
+                    'DE',
+                    'BW',
+                    'HH'
+                  ]
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
           'walletAnalysis',
           {
             call: [
@@ -100,16 +120,60 @@ const descriptor = {
             assign: [
               'admissionState.badgeText',
               {
-                call: [
-                  '__i18n.getTextDescriptor',
+                script: [
                   {
-                    key: {
-                      concatenate: [
-                        'ADMISSION_STATE_',
-                        { var: 'admissionStateTextKeyComponent' },
-                        '_BADGE_TEXT'
-                      ]
-                    }
+                    declare: [
+                      'admissionStateBadgeText',
+                      {
+                        call: [
+                          '__i18n.getTextDescriptor',
+                          {
+                            key: {
+                              concatenate: [
+                                'ADMISSION_STATE_',
+                                { var: 'admissionStateTextKeyComponent' },
+                                '_BADGE_TEXT'
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    if: [
+                      { var: 'hasExistentScenarioIdentifier' },
+                      {
+                        assign: [
+                          'admissionStateBadgeText.localizedText',
+                          {
+                            init: [
+                              'object',
+                              'en',
+                              {
+                                concatenate: [
+                                  { var: 'scenarioIdentifier' },
+                                  '-',
+                                  { var: 'admissionStateBadgeText.localizedText.en' }
+                                ]
+                              },
+                              'de', {
+                                concatenate: [
+                                  { var: 'scenarioIdentifier' },
+                                  '-',
+                                  { var: 'admissionStateBadgeText.localizedText.de' }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    return: [
+                      { var: 'admissionStateBadgeText' }
+                    ]
                   }
                 ]
               }
@@ -143,21 +207,7 @@ const descriptor = {
               'admissionState.subtitleText',
               {
                 if: [
-                  {
-                    and: [
-                      { var: 'hasScenarioIdentifier' },
-                      {
-                        in: [
-                          { var: 'scenarioIdentifier' },
-                          [
-                            'DE',
-                            'BW',
-                            'HH'
-                          ]
-                        ]
-                      }
-                    ]
-                  },
+                  { var: 'hasExistentScenarioIdentifier' },
                   {
                     init: [
                       'object',

--- a/resources/json-schema/ccl-get-dcc-wallet-info.json
+++ b/resources/json-schema/ccl-get-dcc-wallet-info.json
@@ -49,6 +49,9 @@
           "items": {
             "$ref": "https://ccl.coronawarn.app/ccl-commons.json#/$defs/validationRule"
           }
+        },
+        "scenarioIdentifier": {
+          "type": "string"
         }
       }
     },

--- a/test/fixtures/ccl/dcc-series-wallet-info-scenario-identifier.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-scenario-identifier.yaml
@@ -10,6 +10,8 @@
         walletInfo:
           admissionState:
             visible: true
+            badgeText:
+              de: ^2G$
             subtitleText:
               de: ^2G$
     - time: biontech2/2+P100D
@@ -19,6 +21,8 @@
         walletInfo:
           admissionState:
             visible: true
+            badgeText:
+              de: ^DE-2G$
             subtitleText:
               de: ^DE$
     - time: biontech2/2+P100D
@@ -27,6 +31,8 @@
         walletInfo:
           admissionState:
             visible: true
+            badgeText:
+              de: ^BW-2G$
             subtitleText:
               de: ^BW$
     - time: biontech2/2+P100D
@@ -35,5 +41,7 @@
         walletInfo:
           admissionState:
             visible: true
+            badgeText:
+              de: ^HH-2G$
             subtitleText:
               de: ^HH$

--- a/test/fixtures/ccl/dcc-series-wallet-info-scenario-identifier.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-scenario-identifier.yaml
@@ -1,0 +1,39 @@
+- description: walletInfo for 2G
+  t0: '2022-01-01'
+  series:
+    - time: t0
+      vc: biontech2/2
+  testCases:
+    - time: biontech2/2+P100D
+      description: does not change admissionState subtitleText without scenarioIdentifier
+      assertions:
+        walletInfo:
+          admissionState:
+            visible: true
+            subtitleText:
+              de: ^2G$
+    - time: biontech2/2+P100D
+      description: returns the scenarioIdentifier as admissionState
+      scenarioIdentifier: DE
+      assertions:
+        walletInfo:
+          admissionState:
+            visible: true
+            subtitleText:
+              de: ^DE$
+    - time: biontech2/2+P100D
+      scenarioIdentifier: BW
+      assertions:
+        walletInfo:
+          admissionState:
+            visible: true
+            subtitleText:
+              de: ^BW$
+    - time: biontech2/2+P100D
+      scenarioIdentifier: HH
+      assertions:
+        walletInfo:
+          admissionState:
+            visible: true
+            subtitleText:
+              de: ^HH$

--- a/test/unit/ccl/functions/getDccWalletInfo.spec.js
+++ b/test/unit/ccl/functions/getDccWalletInfo.spec.js
@@ -44,7 +44,7 @@ describe('ccl/functions/getDccWalletInfo', async () => {
 
       seriesDescriptor.testCases.forEach((testCase, idx) => {
         const _context = testCase.only === true ? context.only : context
-        const testCaseDescription = `test case #${idx + 1} at ${testCase.time} - ${testCase.description || ''}`
+        const testCaseDescription = `test case #${idx + 1} at ${testCase.time} - ${testCase.description || ''} - scenario '${testCase.scenarioIdentifier || ''}'`
         _context(testCaseDescription, () => {
           let timeUnderTest, seriesUnderTest
           let input, output
@@ -66,6 +66,7 @@ describe('ccl/functions/getDccWalletInfo', async () => {
               }),
               boosterNotificationRules: allBNRs
             }
+            if (typeof testCase.scenarioIdentifier === 'string') input.scenarioIdentifier = testCase.scenarioIdentifier
 
             // output = ccl.evaluateFunction('__analyzeDccWallet', input)
             output = ccl.api.getDccWalletInfo(input)


### PR DESCRIPTION
This PR adds dummy support for the new `scenarioIdentifier` parameter of getDccWalletInfo and reflects the value in the admission state's subtitle text.