### PR TITLE
Feature: Deprioritize booster RCs after 90 days (EXPOSUREAPP-12366)

### DIFF
--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -1178,6 +1178,23 @@ const descriptor = {
       },
       {
         declare: [
+          'allVCsAndRCsWithFullImmunizationForPrioritization',
+          {
+            filter: [
+              { var: 'allVCsAndRCsWithFullImmunization' },
+              {
+                or: [
+                  { var: 'it.__isVC' },
+                  { var: 'it.__isStillValid' }
+                ]
+              },
+              'it'
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
           'hasBooster',
           {
             '!!': [
@@ -1360,10 +1377,10 @@ const descriptor = {
             if: [
               {
                 '!!': [
-                  { var: 'allVCsAndRCsWithFullImmunization' }
+                  { var: 'allVCsAndRCsWithFullImmunizationForPrioritization' }
                 ]
               },
-              { var: 'allVCsAndRCsWithFullImmunization.0' },
+              { var: 'allVCsAndRCsWithFullImmunizationForPrioritization.0' },
               // else if PCR
               {
                 '!!': [

--- a/test/fixtures/ccl/dcc-series-recovery.yaml
+++ b/test/fixtures/ccl/dcc-series-recovery.yaml
@@ -611,14 +611,14 @@
         hasBooster: false
         verificationCertificates:
           - certificate: rc1
-    # recovery still valid after 91 days, but 2G only
+    # recovery still valid after 91 days, but 2G only and not prioritized anymore
     - time: rc1+P91D
       assertions:
         admissionState: 2G
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: janssen1/1
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: 
         mostRecentVaccination: janssen1/1
         hasBooster: false
         verificationCertificates:
-          - certificate: rc1
+          - certificate: janssen1/1

--- a/test/fixtures/ccl/dcc-series-recovery.yaml
+++ b/test/fixtures/ccl/dcc-series-recovery.yaml
@@ -348,7 +348,7 @@
         hasBoosterEquivalent: true
         verificationCertificates:
           - certificate: rc1
-    # recovery still valid after 90 days --> 1G
+    # recovery still valid after 90 days --> 2G+
     - time: rc1+P90D
       assertions:
         admissionState: 2G_PLUS
@@ -360,42 +360,42 @@
         hasBoosterEquivalent: true
         verificationCertificates:
           - certificate: rc1
-    # recovery still valid after 91 days and prioritized
+    # recovery still valid after 91 days but not prioritized anymore
     - time: rc1+P91D
       assertions:
         admissionState: 2G_PLUS
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: biontech2/2
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: biontech2/2+P15D
         mostRecentVaccination: biontech2/2
         hasBooster: false
         hasBoosterEquivalent: true
         verificationCertificates:
-          - certificate: rc1
-    # recovery still valid after 181 days and prioritized
+          - certificate: biontech2/2
+    # recovery still valid after 181 days but not prioritized anymore
     - time: rc1+P181D
       assertions:
         admissionState: 2G_PLUS
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: biontech2/2
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: biontech2/2+P15D
         mostRecentVaccination: biontech2/2
         hasBooster: false
         hasBoosterEquivalent: true
         verificationCertificates:
-          - certificate: rc1
+          - certificate: biontech2/2
     # recovery still valid after 2 years (unlimited) --> 2G_PLUS
     - time: rc1+P2Y
       assertions:
         admissionState: 2G_PLUS
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: biontech2/2
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: biontech2/2+P15D
         mostRecentVaccination: biontech2/2
         hasBooster: false
         hasBoosterEquivalent: true
         verificationCertificates:
-          - certificate: rc1
+          - certificate: biontech2/2
 - description: recovery + J&J
   t0: '2022-01-01'
   series:

--- a/test/fixtures/ccl/dcc-series-recovery.yaml
+++ b/test/fixtures/ccl/dcc-series-recovery.yaml
@@ -525,13 +525,13 @@
     - time: rc1+P91D
       assertions:
         admissionState: 2G
-        mostRelevantCertificate: rc1
+        mostRelevantCertificate: biontech1/2
         vaccinationState: COMPLETE_IMMUNIZATION
         vaccinationValidFrom: 
         mostRecentVaccination: biontech1/2
         hasBooster: false
         verificationCertificates:
-          - certificate: rc1
+          - certificate: biontech1/2
     # vaccination valid immedeately
     - time: biontech2/2
       assertions:


### PR DESCRIPTION
Related to:
- https://github.com/corona-warn-app/cwa-app-ccl/issues/49