### PR TITLE
Fix: Detect DCC renewal if family name is absent (EXPOSUREAPP-13727, EXPOSUREAPP-13787)

### DIFF
--- a/lib/ccl/ccl-main.js
+++ b/lib/ccl/ccl-main.js
@@ -19,7 +19,7 @@ const validateSchema = async (instance, $ref) => {
     'ccl-configuration.json',
     'ccl-get-dcc-wallet-info.json',
     'dcc-validation-rule.json',
-    'digital-covid-certificate-1.3.0.json',
+    'digital-covid-certificate-1.3.2.json',
     'jfn-function-descriptor.json'
   ]
   await async.forEach(relatedSchemes, async filename => {

--- a/lib/ccl/functions/__holder.equals.js
+++ b/lib/ccl/functions/__holder.equals.js
@@ -110,38 +110,85 @@ const descriptor = {
         ]
       },
       {
-        if: [
+        declare: [
+          'emptyBothGnt',
           {
             and: [
               {
-                or: [
-                  // match in gnt
+                '!': [
+                  { var: 'holderAComponentsGnt' }
+                ]
+              },
+              {
+                '!': [
+                  { var: 'holderBComponentsGnt' }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'emptyBothFnt',
+          {
+            and: [
+              {
+                '!': [
+                  { var: 'holderAComponentsFnt' }
+                ]
+              },
+              {
+                '!': [
+                  { var: 'holderBComponentsFnt' }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        if: [
+          {
+            or: [
+              // (intersectionAGntWithBGnt.length >= 1 || emptyBothGnt) && intersectionAFntWithBFnt.length >= 1
+              {
+                and: [
                   {
-                    '!!': [
-                      { var: 'intersectionAGntWithBGnt' }
-                    ]
-                  },
-                  // both gnt are empty
-                  {
-                    and: [
+                    or: [
                       {
-                        '!': [
-                          { var: 'holderAComponentsGnt' }
+                        '!!': [
+                          { var: 'intersectionAGntWithBGnt' }
                         ]
                       },
-                      {
-                        '!': [
-                          { var: 'holderBComponentsGnt' }
-                        ]
-                      }
+                      { var: 'emptyBothGnt' }
+                    ]
+                  },
+                  {
+                    '!!': [
+                      { var: 'intersectionAFntWithBFnt' }
                     ]
                   }
                 ]
               },
-              // match in fnt
+              // (intersectionAFntWithBFnt.length >= 1 || emptyBothFnt) && intersectionAGntWithBGnt.length >= 1
               {
-                '!!': [
-                  { var: 'intersectionAFntWithBFnt' }
+                and: [
+                  {
+                    or: [
+                      {
+                        '!!': [
+                          { var: 'intersectionAFntWithBFnt' }
+                        ]
+                      },
+                      { var: 'emptyBothFnt' }
+                    ]
+                  },
+                  {
+                    '!!': [
+                      { var: 'intersectionAGntWithBGnt' }
+                    ]
+                  }
                 ]
               }
             ]
@@ -153,59 +200,125 @@ const descriptor = {
           }
         ]
       },
-      // {
-      //   declare: [
-      //     'intersectionAGntWithBFnt',
-      //     {
-      //       call: [
-      //         '__intersectArrays',
-      //         {
-      //           arrayA: { var: 'holderAComponentsGnt' },
-      //           arrayB: { var: 'holderBComponentsFnt' }
-      //         }
-      //       ]
-      //     }
-      //   ]
-      // },
-      // {
-      //   declare: [
-      //     'intersectionAFntWithBGnt',
-      //     {
-      //       call: [
-      //         '__intersectArrays',
-      //         {
-      //           arrayA: { var: 'holderAComponentsFnt' },
-      //           arrayB: { var: 'holderBComponentsGnt' }
-      //         }
-      //       ]
-      //     }
-      //   ]
-      // },
-      // {
-      //   if : [
-      //     {
-      //       and: [
-      //         // match in intersectionAGntWithBFnt
-      //         {
-      //           '!!': [
-      //             { var: 'intersectionAGntWithBFnt' }
-      //           ]
-      //         },
-      //         // match in intersectionAFntWithBGnt
-      //         {
-      //           '!!': [
-      //             { var: 'intersectionAFntWithBGnt' }
-      //           ]
-      //         }
-      //       ]
-      //     },
-      //     {
-      //       return: [
-      //         true
-      //       ]
-      //     }
-      //   ]
-      // },
+      {
+        declare: [
+          'intersectionAGntWithBFnt',
+          {
+            call: [
+              '__intersectArrays',
+              {
+                arrayA: { var: 'holderAComponentsGnt' },
+                arrayB: { var: 'holderBComponentsFnt' }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'intersectionAFntWithBGnt',
+          {
+            call: [
+              '__intersectArrays',
+              {
+                arrayA: { var: 'holderAComponentsFnt' },
+                arrayB: { var: 'holderBComponentsGnt' }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'emptyAGntAndBFnt',
+          {
+            and: [
+              {
+                '!': [
+                  { var: 'holderAComponentsGnt' }
+                ]
+              },
+              {
+                '!': [
+                  { var: 'holderBComponentsFnt' }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'emptyAFntAndBGnt',
+          {
+            and: [
+              {
+                '!': [
+                  { var: 'holderAComponentsFnt' }
+                ]
+              },
+              {
+                '!': [
+                  { var: 'holderBComponentsGnt' }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        if: [
+          {
+            or: [
+              // (intersectionAFntWithBGnt.length >= 1 || emptyAFntAndBGnt) && intersectionAGntWithBFnt.length >= 1
+              {
+                and: [
+                  {
+                    or: [
+                      {
+                        '!!': [
+                          { var: 'intersectionAFntWithBGnt' }
+                        ]
+                      },
+                      { var: 'emptyAFntAndBGnt' }
+                    ]
+                  },
+                  {
+                    '!!': [
+                      { var: 'intersectionAGntWithBFnt' }
+                    ]
+                  }
+                ]
+              },
+              // (intersectionAGntWithBFnt.length >= 1 || emptyAGntAndBFnt) && intersectionAFntWithBGnt.length >= 1
+              {
+                and: [
+                  {
+                    or: [
+                      {
+                        '!!': [
+                          { var: 'intersectionAGntWithBFnt' }
+                        ]
+                      },
+                      { var: 'emptyAGntAndBFnt' }
+                    ]
+                  },
+                  {
+                    '!!': [
+                      { var: 'intersectionAFntWithBGnt' }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            return: [
+              true
+            ]
+          }
+        ]
+      },
       {
         return: [
           false

--- a/resources/json-schema/digital-covid-certificate-1.3.2.json
+++ b/resources/json-schema/digital-covid-certificate-1.3.2.json
@@ -3,13 +3,49 @@
   "$id": "https://id.uvci.eu/DCC.combined-schema.json",
   "title": "EU DCC",
   "description": "EU Digital Covid Certificate",
-  "$comment": "Schema version 1.3.0",
-  "required": [
-    "ver",
-    "nam",
-    "dob"
-  ],
+  "$comment": "Schema version 1.3.2",
   "type": "object",
+  "oneOf": [
+    {
+      "required": [
+        "ver",
+        "nam",
+        "dob",
+        "v"
+      ],
+      "properties": {
+        "v": {
+          "minItems": 1
+        }
+      }
+    },
+    {
+      "required": [
+        "ver",
+        "nam",
+        "dob",
+        "t"
+      ],
+      "properties": {
+        "t": {
+          "minItems": 1
+        }
+      }
+    },
+    {
+      "required": [
+        "ver",
+        "nam",
+        "dob",
+        "r"
+      ],
+      "properties": {
+        "r": {
+          "minItems": 1
+        }
+      }
+    }
+  ],
   "properties": {
     "ver": {
       "title": "Schema version",
@@ -17,7 +53,10 @@
       "type": "string",
       "pattern": "^\\d+.\\d+.\\d+$",
       "examples": [
-        "1.3.0"
+        "1.0.0",
+        "1.3.0",
+        "1.3.1",
+        "1.3.2"
       ]
     },
     "nam": {
@@ -42,7 +81,7 @@
       "items": {
         "$ref": "#/$defs/vaccination_entry"
       },
-      "minItems": 1,
+      "_minItems": 1,
       "maxItems": 1
     },
     "t": {
@@ -51,7 +90,7 @@
       "items": {
         "$ref": "#/$defs/test_entry"
       },
-      "minItems": 1,
+      "_minItems": 1,
       "maxItems": 1
     },
     "r": {
@@ -60,7 +99,7 @@
       "items": {
         "$ref": "#/$defs/recovery_entry"
       },
-      "minItems": 1,
+      "_minItems": 1,
       "maxItems": 1
     }
   },
@@ -77,8 +116,17 @@
     },
     "person_name": {
       "description": "Person name: Surname(s), forename(s) - in that order",
-      "required": [
-        "fnt"
+      "anyOf": [
+        {
+          "required": [
+            "fnt"
+          ]
+        },
+        {
+          "required": [
+            "gnt"
+          ]
+        }
       ],
       "type": "object",
       "properties": {
@@ -203,6 +251,7 @@
       "type": "object",
       "properties": {
         "tg": {
+          "description": "disease or agent targeted",
           "$ref": "#/$defs/disease-agent-targeted"
         },
         "tt": {
@@ -260,6 +309,7 @@
       "type": "object",
       "properties": {
         "tg": {
+          "description": "disease or agent targeted",
           "$ref": "#/$defs/disease-agent-targeted"
         },
         "fr": {

--- a/test/fixtures/ccl/dcc-holder-comparison.gen.json
+++ b/test/fixtures/ccl/dcc-holder-comparison.gen.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Generated at Mon Mar 14 2022 11:06:46 GMT+0100 (Central European Standard Time)",
-  "$sourceHash": "daa5b26f10af1adcf1cc78a9b6d8a1298c31548c3f28d396ebbb938ab22b9f43",
+  "$comment": "Generated at Mon Aug 08 2022 12:22:20 GMT+0200 (Central European Summer Time)",
+  "$sourceHash": "310d05c317544e54a20b8be2f25c4a26ed57bc57ea4e2c3be72fc70462709fd9",
   "data": [
     {
       "description": "happy path - match",
@@ -400,7 +400,7 @@
       "expIsSameHolder": false
     },
     {
-      "description": "match if both first names are empty (gnt is optional)",
+      "description": "match if both first names are empty (only one of fnt/gnt is mandatory)",
       "actHolderA": {
         "nam": {
           "gnt": "",
@@ -412,6 +412,56 @@
         "nam": {
           "gnt": "",
           "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both first names are absent (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both last names are empty (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both last names are absent (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "ERIKA"
         },
         "dob": "1980-02-03"
       },
@@ -581,7 +631,6 @@
       "expIsSameHolder": true
     },
     {
-      "ignore": true,
       "description": "edge case for swapped first/last name",
       "actHolderA": {
         "nam": {
@@ -594,6 +643,42 @@
         "nam": {
           "gnt": "MUSTERMANN<MARIA",
           "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "edge case for swapped first/last name with empty name component (1)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "",
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "MUSTERMANN",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "edge case for swapped first/last name with empty name component (2)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "MUSTERMANN",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "",
+          "fnt": "MUSTERMANN"
         },
         "dob": "1980-02-03"
       },

--- a/test/fixtures/ccl/dcc-series-reissuance-renew.yaml
+++ b/test/fixtures/ccl/dcc-series-reissuance-renew.yaml
@@ -295,4 +295,28 @@
   testCases:
     - time: biontech2/2
       assertions:
-        certificateReissuance: false
+        certificateReissuance:
+          certificates:
+            - action: renew
+              certificateToReissue: biontech2/2
+- description: VCs with GNT-only and that are soon expiring are eligible (EXPOSUREAPP-13727, EXPOSUREAPP-13787)
+  t0: '2022-01-01'
+  defaultDccDescriptor:
+    dccOverwrites:
+      - 'nam.gn=undefined'
+      - 'nam.fn=undefined'
+      - 'nam.fnt=undefined'
+  series:
+    - time: t0
+      vc: janssen1/1
+      dccDescriptor:
+    - time: t0+P6W
+      vc: biontech2/2
+      cwtExp: t0+P7W
+  testCases:
+    - time: biontech2/2
+      assertions:
+        certificateReissuance:
+          certificates:
+            - action: renew
+              certificateToReissue: biontech2/2

--- a/test/util/dcc/dcc-generate.js
+++ b/test/util/dcc/dcc-generate.js
@@ -93,7 +93,7 @@ const generate = async ({
     dccOverwrites.forEach(param => {
       const [partialPath, _newValue] = param.split('=')
       const pathExpression = `$..${partialPath}`
-      if (_newValue === undefined) {
+      if (_newValue === undefined || _newValue === 'undefined') {
         const pathComponents = jp.parse(pathExpression)
         const leafComponent = pathComponents.pop()
         const parentPathExpression = jp.stringify(pathComponents)


### PR DESCRIPTION
With the adoption of the DCC schema [1.3.2](https://github.com/ehn-dcc-development/eu-dcc-schema/releases/tag/1.3.2) where at least one of `nam.fnt` and `nam.gnt` is required (instead of always requiring `nam.fnt`), the name comparison in CCL is adjusted.