### PR TITLE
Fix: process partial dob for Booster Notification evaluation (EXPOSUREAPP-12543)

### DIFF
--- a/lib/ccl/functions/__evaluateBoosterNotificationRules.js
+++ b/lib/ccl/functions/__evaluateBoosterNotificationRules.js
@@ -39,6 +39,131 @@ const descriptor = {
           }
         ]
       },
+      // process partial dob
+      {
+        declare: [
+          'dobChunks',
+          {
+            split: [
+              { var: 'payload.dob' },
+              '-'
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'newDob',
+          {
+            if: [
+              // if dob is complete
+              {
+                '===': [
+                  {
+                    count: [
+                      { var: 'dobChunks' }
+                    ]
+                  },
+                  3
+                ]
+              },
+              // then leave it as-is
+              { var: 'payload.dob' },
+              // else if dob is partial YYYY-MM
+              {
+                '===': [
+                  {
+                    count: [
+                      { var: 'dobChunks' }
+                    ]
+                  },
+                  2
+                ]
+              },
+              // then add `-01` to complete the date
+              {
+                concatenate: [
+                  { var: 'payload.dob' },
+                  '-01'
+                ]
+              },
+              // else if dob is partial YYYY
+              {
+                and: [
+                  {
+                    '===': [
+                      {
+                        count: [
+                          { var: 'dobChunks' }
+                        ]
+                      },
+                      1
+                    ]
+                  },
+                  // first chunk is not empty
+                  {
+                    '!!': [
+                      { var: 'dobChunks.0' }
+                    ]
+                  }
+                ]
+              },
+              // then add `-01-01` to complete the date
+              {
+                concatenate: [
+                  { var: 'payload.dob' },
+                  '-01-01'
+                ]
+              },
+              // else, set it to 18 years
+              {
+                plusTime: [
+                  { var: 'validationClock' },
+                  -18,
+                  'year'
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        assign: [
+          'payload.dob',
+          { var: 'newDob' }
+        ]
+      },
+      {
+        if: [
+          {
+            '!==': [
+              {
+                count: [
+                  {
+                    split: [
+                      { var: 'payload.dob' },
+                      '-'
+                    ]
+                  }
+                ]
+              },
+              3
+            ]
+          },
+          {
+            assign: [
+              'payload.dob',
+              {
+                plusTime: [
+                  { var: 'validationClock' },
+                  -18,
+                  'year'
+                ]
+              }
+            ]
+          }
+        ]
+      },
       {
         declare: [
           'external',

--- a/test/fixtures/ccl/bnr-tx-0004.json
+++ b/test/fixtures/ccl/bnr-tx-0004.json
@@ -1,0 +1,35 @@
+{
+  "Identifier": "BNR-TX-0004",
+  "Type": "BoosterNotification",
+  "Country": "TX",
+  "Version": "1.0.0",
+  "SchemaVersion": "1.0.0",
+  "Engine": "CERTLOGIC",
+  "EngineVersion": "1.0.0",
+  "CertificateType": "General",
+  "Description": [
+    {
+      "lang": "de",
+      "desc": "BNR-TX-0004 Langtext"
+    },
+    {
+      "lang": "en",
+      "desc": "BNR-TX-0004 long text"
+    }
+  ],
+  "ValidFrom": "2021-10-07T00:00:00Z",
+  "ValidTo": "2030-06-01T00:00:00Z",
+  "AffectedFields": [],
+  "Logic": {
+    ">=": [
+      {
+        "diffTime": [
+          { "var": "external.validationClock" },
+          { "var": "payload.dob" },
+          "year"
+        ]
+      },
+      100
+    ]
+  }
+}

--- a/test/fixtures/ccl/bnr-tx-0005.json
+++ b/test/fixtures/ccl/bnr-tx-0005.json
@@ -1,0 +1,35 @@
+{
+  "Identifier": "BNR-TX-0005",
+  "Type": "BoosterNotification",
+  "Country": "TX",
+  "Version": "1.0.0",
+  "SchemaVersion": "1.0.0",
+  "Engine": "CERTLOGIC",
+  "EngineVersion": "1.0.0",
+  "CertificateType": "General",
+  "Description": [
+    {
+      "lang": "de",
+      "desc": "BNR-TX-0005 Langtext"
+    },
+    {
+      "lang": "en",
+      "desc": "BNR-TX-0005 long text"
+    }
+  ],
+  "ValidFrom": "2021-10-07T00:00:00Z",
+  "ValidTo": "2030-06-01T00:00:00Z",
+  "AffectedFields": [],
+  "Logic": {
+    "===": [
+      {
+        "diffTime": [
+          { "var": "external.validationClock" },
+          { "var": "payload.dob" },
+          "year"
+        ]
+      },
+      18
+    ]
+  }
+}

--- a/test/fixtures/ccl/dcc-series-wallet-info-bnr.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-bnr.yaml
@@ -145,3 +145,75 @@
         walletInfo:
           boosterNotification:
             visible: true
+- description: BNRs can be calculated based on age
+  t0: '2022-01-01'
+  series:
+    - time: t0
+      vc: astra1/2
+      dccDescriptor:
+        dccOverwrites:
+          - 'dob=1920-01-01' # more than 100 years old
+  testCases:
+    - time: astra1/2
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0004'
+- description: EXPOSUREAPP-12543 - BNRs assume a default age of 18 if dob is empty
+  t0: '2022-01-01'
+  series:
+    - time: t0
+      vc: astra1/2
+      dccDescriptor:
+        dccOverwrites:
+          - 'dob='
+  testCases:
+    - time: astra1/2
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0005'
+- description: EXPOSUREAPP-12543 - BNRs complete partial dob YYYY with 01-01
+  t0: '2022-01-01'
+  series:
+    - time: t0
+      vc: astra1/2
+      dccDescriptor:
+        dccOverwrites:
+          - 'dob=2004'
+  testCases:
+    - time: '2022-01-01'
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0005'
+    - time: '2104-01-01'
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0004'
+- description: EXPOSUREAPP-12543 - BNRs complete partial dob YYYY-MM with 01
+  t0: '2022-01-01'
+  series:
+    - time: t0
+      vc: astra1/2
+      dccDescriptor:
+        dccOverwrites:
+          - 'dob=2004-02'
+  testCases:
+    - time: '2022-02-01'
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0005'
+    - time: '2104-02-01'
+      assertions:
+        walletInfo:
+          boosterNotification:
+            visible: true
+            identifier: 'BNR-TX-0004'


### PR DESCRIPTION
The BNR evaluation crashes with partial dob so this PR completes partial dob in the context of BNRs.