### PR TITLE
Feature: Determine vaccination state based on latest IfSG (EXPOSUREAPP-13915)

### DIFF
--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -458,6 +458,69 @@ const descriptor = {
                           },
                           {
                             assign: [
+                              'it.__isAtLeast2OfN',
+                              {
+                                and: [
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      2
+                                    ]
+                                  },
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      { var: 'it.hcert.v.0.sd' }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            assign: [
+                              'it.__isAtLeast3OfN',
+                              {
+                                and: [
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      3
+                                    ]
+                                  },
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      { var: 'it.hcert.v.0.sd' }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            assign: [
+                              'it.__isAtLeast4OfN',
+                              {
+                                and: [
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      4
+                                    ]
+                                  },
+                                  {
+                                    '>=': [
+                                      { var: 'it.hcert.v.0.dn' },
+                                      { var: 'it.hcert.v.0.sd' }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            assign: [
                               'it.__isDnAboveSd',
                               {
                                 '>': [
@@ -1878,146 +1941,77 @@ const descriptor = {
                 ]
               },
               {
-                if: [
-                  {
-                    and: [
-                      { var: 'first.__isVC' },
-                      { var: 'first.__isBooster' }
-                    ]
-                  },
-                  {
-                    return: [
-                      'COMPLETE_BOOSTER'
-                    ]
-                  },
-                  // else if
-                  {
-                    and: [
-                      { var: 'first.__isRC' },
-                      { var: 'first.__isBooster' },
-                      { var: 'first.__hasPreviousFullImmunization' }
-                    ]
-                  },
-                  {
-                    return: [
-                      'COMPLETE_BOOSTER_RC'
-                    ]
-                  },
-                  // else if
-                  {
-                    and: [
-                      { var: 'first.__isRC' },
-                      { var: 'first.__hasSomePreviousVaccination' },
-                      {
-                        '!': [
-                          { var: 'first.__hasPreviousPartialVaccination' }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    return: [
-                      'COMPLETE_BOOSTER_RC_PENDING'
-                    ]
-                  }
-                ]
-              },
-              {
                 declare: [
-                  'immunizationMatch',
+                  'firstVC',
                   {
                     find: [
                       { var: 'allRelevantVCsAndRCsAnnotatedWithContext' },
-                      {
-                        and: [
-                          {
-                            or: [
-                              { var: 'it.__isVC' },
-                              // prevent that a single RC can lead to COMPLETE_IMMUNIZATION
-                              { var: 'it.__hasSomePreviousVaccination' }
-                            ]
-                          },
-                          { var: 'it.__isFullImmunization' }
-                        ]
-                      },
+                      { var: 'it.__isVC' },
                       'it'
                     ]
                   }
                 ]
               },
               {
-                if: [
-                  { var: 'immunizationMatch.__isVC' },
-                  {
-                    return: [
-                      'COMPLETE_IMMUNIZATION'
-                    ]
-                  },
-                  { var: 'immunizationMatch.__isRC' },
-                  {
-                    return: [
-                      'COMPLETE_IMMUNIZATION_RC'
-                    ]
-                  }
-                ]
-              },
-              {
                 declare: [
-                  'pendingImmunizationMatch',
+                  'state',
                   {
-                    find: [
-                      { var: 'allRelevantVCsAndRCsAnnotatedWithContext' },
+                    if: [
                       {
                         or: [
+                          { var: 'firstVC.__isAtLeast4OfN' },
                           {
                             and: [
-                              { var: 'it.__isRC' },
-                              { var: 'it.__hasSomePreviousVaccination' },
-                              {
-                                '!': [
-                                  { var: 'it.__isAlreadyValid' }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            and: [
-                              { var: 'it.__isVC' },
-                              {
-                                after: [
-                                  { var: 'it.__fullImmunizationDate' },
-                                  { var: 'now.localDateTime' }
-                                ]
-                              },
-                              { var: 'it.__isNotJanssen1Of1' }
+                              { var: 'firstVC.__isAtLeast3OfN' },
+                              { var: 'first.__isRC' }
                             ]
                           }
                         ]
                       },
-                      'it'
-                    ]
-                  }
-                ]
-              },
-              {
-                if: [
-                  { var: 'pendingImmunizationMatch.__isVC' },
-                  {
-                    return: [
-                      'COMPLETE_IMMUNIZATION_PENDING'
-                    ]
-                  },
-                  { var: 'pendingImmunizationMatch.__isRC' },
-                  {
-                    return: [
-                      'COMPLETE_IMMUNIZATION_RC_PENDING'
+                      'COMPLETE_BOOSTER',
+                      // else if
+                      { var: 'firstVC.__isAtLeast3OfN' },
+                      'COMPLETE_IMMUNIZATION',
+                      // else if
+                      {
+                        and: [
+                          { var: 'firstVC.__isAtLeast2OfN' },
+                          { var: 'first.__isRC' },
+                          { var: 'first.__isAlreadyValid' }
+                        ]
+                      },
+                      'COMPLETE_IMMUNIZATION_RC',
+                      // else if
+                      {
+                        and: [
+                          { var: 'firstVC.__isAtLeast2OfN' },
+                          { var: 'first.__isRC' },
+                          {
+                            '!': [
+                              { var: 'first.__isAlreadyValid' }
+                            ]
+                          }
+                        ]
+                      },
+                      'COMPLETE_IMMUNIZATION_RC_PENDING',
+                      // else if
+                      {
+                        and: [
+                          { var: 'first.__isVC' },
+                          { var: 'first.__isAtLeast2OfN' },
+                          { var: 'first.__hasPreviousRC' }
+                        ]
+                      },
+                      'COMPLETE_IMMUNIZATION_RC',
+                      // else
+                      'PARTIAL_IMMUNIZATION'
                     ]
                   }
                 ]
               },
               {
                 return: [
-                  'PARTIAL_IMMUNIZATION'
+                  { var: 'state' }
                 ]
               }
             ]
@@ -2042,6 +2036,24 @@ const descriptor = {
           {
             '!!': [
               { var: 'allTCsWithValidRATForMaskState' }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'maskState_first',
+          { var: 'allRelevantVCsAndRCsAnnotatedWithContext.0' }
+        ]
+      },
+      {
+        declare: [
+          'maskState_firstVC',
+          {
+            find: [
+              { var: 'allRelevantVCsAndRCsAnnotatedWithContext' },
+              { var: 'it.__isVC' },
+              'it'
             ]
           }
         ]
@@ -2145,10 +2157,36 @@ const descriptor = {
                 if: [
                   {
                     or: [
-                      { var: 'maskState_hasValidRC' },
+                      {
+                        and: [
+                          { var: 'maskState_first.__isRC' },
+                          { var: 'maskState_first.__isValid' }
+                        ]
+                      },
+                      {
+                        and: [
+                          { var: 'maskState_first.__isVC' },
+                          { var: 'maskState_first.__isAtLeast4OfN' },
+                          { var: 'maskState_first.__isYoungerThan91Days' }
+                        ]
+                      },
+                      {
+                        and: [
+                          { var: 'maskState_first.__isVC' },
+                          { var: 'maskState_first.__isAtLeast3OfN' },
+                          { var: 'maskState_first.__isYoungerThan91Days' }
+                        ]
+                      },
+                      {
+                        and: [
+                          { var: 'maskState_first.__isVC' },
+                          { var: 'maskState_first.__isAtLeast2OfN' },
+                          { var: 'maskState_first.__isYoungerThan91Days' },
+                          { var: 'maskState_first.__hasPreviousRC' }
+                        ]
+                      },
                       { var: 'hasRATForMaskState' },
-                      { var: 'hasPCRForMaskState' },
-                      { var: 'maskState_VCAfterRC' }
+                      { var: 'hasPCRForMaskState' }
                     ]
                   },
                   'MASK_OPTIONAL',

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -122,19 +122,19 @@
   </plurals>
   <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION_RC_PENDING Card Long Text -->
   <plurals name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_RC_PENDING_LONG_TEXT">
-    <item quantity="zero">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
-    <item quantity="one">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tag wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
-    <item quantity="two">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
-    <item quantity="few">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
-    <item quantity="many">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
-    <item quantity="other">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können.</item>
+    <item quantity="zero">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
+    <item quantity="one">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tag wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
+    <item quantity="two">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
+    <item quantity="few">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
+    <item quantity="many">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
+    <item quantity="other">Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in %1$d Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.</item>
   </plurals>
   <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION Card Long Text -->
-  <string name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_LONG_TEXT">"Sie haben alle Impfungen der Grundimmunisierung erhalten. Ihr Impfschutz ist wirksam. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen."</string>
+  <string name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_LONG_TEXT">"Sie haben alle Impfungen für einen vollständigen Impfschutz erhalten. Ihr Impfschutz ist wirksam. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen."</string>
   <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION_RC Card Long Text -->
-  <string name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_RC_LONG_TEXT">"Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als grundimmunisiert. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen."</string>
+  <string name="VACCINATION_STATE_COMPLETE_IMMUNIZATION_RC_LONG_TEXT">"Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen."</string>
   <!-- XTXT: Vaccination State - PARTIAL_IMMUNIZATION Card Long Text -->
-  <string name="VACCINATION_STATE_PARTIAL_IMMUNIZATION_LONG_TEXT">"Sie haben noch nicht alle derzeit geplanten Impfungen erhalten. Daher ist Ihr Impfschutz noch nicht vollständig."</string>
+  <string name="VACCINATION_STATE_PARTIAL_IMMUNIZATION_LONG_TEXT">"Sie haben noch nicht alle derzeit empfohlenen Impfungen erhalten. Ihr Impfschutz ist noch nicht vollständig."</string>
   
   <!-- XTXT: Vaccination State - COMPLETE_IMMUNIZATION Card Subtitle -->
   <string name="PERSON_VIEW_2G_CERTIFICATE">"2G-Zertifikat"</string>

--- a/test/fixtures/ccl/dcc-series-allowed-vaccines.yaml
+++ b/test/fixtures/ccl/dcc-series-allowed-vaccines.yaml
@@ -1,10 +1,12 @@
-- description: biontech 1/2 + biontech 2/2
+- description: biontech 1/2 + biontech 2/2 + biontech 3/3
   t0: '2022-01-01'
   series:
     - time: t0
       vc: biontech1/2
     - time: +P6W
       vc: biontech2/2
+    - time: +P6W
+      vc: biontech3/3
   testCases:
     - time: biontech1/2
       assertions:
@@ -15,19 +17,27 @@
     - time: biontech2/2
       assertions:
         mostRelevantCertificate: biontech2/2
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
+        vaccinationState: PARTIAL_IMMUNIZATION
         verificationCertificates:
           - certificate: biontech2/2
     - time: biontech2/2+P15D
       assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech3/3
+      assertions:
+        mostRelevantCertificate: biontech3/3
         vaccinationState: COMPLETE_IMMUNIZATION
-- description: moderna 1/2 + moderna 2/2
+        verificationCertificates:
+          - certificate: biontech3/3
+- description: moderna 1/2 + moderna 2/2 + moderna 3/3
   t0: '2022-01-01'
   series:
     - time: t0
       vc: moderna1/2
     - time: +P6W
       vc: moderna2/2
+    - time: +P6W
+      vc: moderna3/3
   testCases:
     - time: moderna1/2
       assertions:
@@ -38,19 +48,27 @@
     - time: moderna2/2
       assertions:
         mostRelevantCertificate: moderna2/2
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
+        vaccinationState: PARTIAL_IMMUNIZATION
         verificationCertificates:
           - certificate: moderna2/2
     - time: moderna2/2+P15D
       assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: moderna3/3
+      assertions:
+        mostRelevantCertificate: moderna3/3
         vaccinationState: COMPLETE_IMMUNIZATION
-- description: astra 1/2 + astra 2/2
+        verificationCertificates:
+          - certificate: moderna3/3
+- description: astra 1/2 + astra 2/2 + astra 3/3
   t0: '2022-01-01'
   series:
     - time: t0
       vc: astra1/2
     - time: +P6W
       vc: astra2/2
+    - time: +P6W
+      vc: astra3/3
   testCases:
     - time: astra1/2
       assertions:
@@ -61,12 +79,18 @@
     - time: astra2/2
       assertions:
         mostRelevantCertificate: astra2/2
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
+        vaccinationState: PARTIAL_IMMUNIZATION
         verificationCertificates:
           - certificate: astra2/2
     - time: astra2/2+P15D
       assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: astra3/3
+      assertions:
+        mostRelevantCertificate: astra3/3
         vaccinationState: COMPLETE_IMMUNIZATION
+        verificationCertificates:
+          - certificate: astra3/3
 - description: novavax 1/2 + novavax 2/2 + novavax 3/3
   t0: '2022-01-01'
   series:
@@ -86,17 +110,17 @@
     - time: novavax2/2
       assertions:
         mostRelevantCertificate: novavax2/2
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
+        vaccinationState: PARTIAL_IMMUNIZATION
         verificationCertificates:
           - certificate: novavax2/2
     - time: novavax2/2+P15D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
+        vaccinationState: PARTIAL_IMMUNIZATION
     - time: novavax3/3
       description: Novavax 3/3 is valid immediately
       assertions:
         mostRelevantCertificate: novavax3/3
-        vaccinationState: COMPLETE_BOOSTER
+        vaccinationState: COMPLETE_IMMUNIZATION
         verificationCertificates:
           - certificate: novavax3/3
 - description: legacy novavax 1/2 + novavax 2/2 + novavax 3/3
@@ -118,16 +142,16 @@
     - time: legacyNovavax2/2
       assertions:
         mostRelevantCertificate: legacyNovavax2/2
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
+        vaccinationState: PARTIAL_IMMUNIZATION
         verificationCertificates:
           - certificate: legacyNovavax2/2
     - time: legacyNovavax2/2+P15D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
+        vaccinationState: PARTIAL_IMMUNIZATION
     - time: legacyNovavax3/3
       description: legacyNovavax 3/3 is valid immediately
       assertions:
         mostRelevantCertificate: legacyNovavax3/3
-        vaccinationState: COMPLETE_BOOSTER
+        vaccinationState: COMPLETE_IMMUNIZATION
         verificationCertificates:
           - certificate: legacyNovavax3/3

--- a/test/fixtures/ccl/dcc-series-wallet-info-vaccination-state.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-vaccination-state.yaml
@@ -1,563 +1,532 @@
-- description: biontech 1/2 + biontech 2/2 + biontech 3/3 (same for moderna, astra, and nova)
-  t0: '2022-01-01'
+- description: 0.1 - VC 1/2
+  t0: '2022-08-01'
   series:
     - time: t0
       vc: biontech1/2
-    - time: +P6W
-      vc: biontech2/2
-    - time: +P6W
-      vc: biontech3/3
   testCases:
     - time: biontech1/2
       assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.8
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/2+P15D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/2+P29D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/2+P91D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/2
+      description: long text test
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
         walletInfo:
           vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung heute
             longText:
-              de: noch nicht vollständig
-            faqAnchor: vac_status
-    - time: biontech1/2+P1D
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 1 Tag
-    - time: biontech1/2+P2D
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 2 Tagen
+              de: ^Sie haben noch nicht alle derzeit empfohlenen Impfungen erhalten\. Ihr Impfschutz ist noch nicht vollständig\.$
+
+- description: 0.1 - VC 2/2
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech2/2
+  testCases:
     - time: biontech2/2
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING # seq no 0.6
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 15 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P1D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 1 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 14 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P14D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 14 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 1 Tag wirksam.*empfohlene Auffrischimpfungen
+        vaccinationState: PARTIAL_IMMUNIZATION
     - time: biontech2/2+P15D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.9 + 3.4
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 15 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P16D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 16 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech3/3
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.17
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-            longText:
-              de: alle derzeit empfohlenen Impfungen.*Impfschutz ist vollständig.
-- description: biontech 1/1 (recovery vaccination; same for moderna, astra, and nova) + biontech 2/1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: biontech1/1
-    - time: +P6W
-      vc: biontech2/1
-  testCases:
-    - time: biontech1/1
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.6 + 3.8
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech1/1+P1D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 1 Tag
-    - time: biontech1/1+P2D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 2 Tagen
-    - time: biontech2/1
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.11
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-            longText:
-              de: alle derzeit empfohlenen Impfungen.*Impfschutz ist vollständig.
-- description: janssen 1/1 + biontech 2/1 + biontech3/1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: janssen1/1
-    - time: +P4W
-      vc: biontech2/1
-    - time: +P4W
-      vc: biontech3/1
-  testCases:
-    - time: janssen1/1
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.1
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: noch nicht vollständig
-    - time: janssen1/1+P15D
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech2/2+P29D
       assertions:
         vaccinationState: PARTIAL_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 15 Tage
-            longText:
-              de: noch nicht vollständig
+    - time: biontech2/2+P91D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 0.1 - VC 2/1
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech2/1
+  testCases:
     - time: biontech2/1
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING # seq no 0.5
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 15 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/1+P1D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 1 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 14 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/1+P14D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 14 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 1 Tag wirksam.*empfohlene Auffrischimpfungen
+        vaccinationState: PARTIAL_IMMUNIZATION
     - time: biontech2/1+P15D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.5 + 3.3
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 15 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/1+P16D
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech2/1+P29D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 16 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech3/1+P15D
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech2/1+P91D
       assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.16
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-            longText:
-              de: alle derzeit empfohlenen Impfungen.*Impfschutz ist vollständig.
-- description: janssen 1/1 + biontech 2/2 (old notation)
-  t0: '2022-01-01'
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 0.1 - VC 2/1 janssen (no special logic)
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: janssen2/1
+  testCases:
+    - time: janssen2/1
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: janssen2/1+P15D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: janssen2/1+P29D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: janssen2/1+P91D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 0.1 - VC 1/1
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech1/1
+  testCases:
+    - time: biontech1/1
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/1+P15D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/1+P29D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: biontech1/1+P91D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 0.1 - VC 1/1 janssen (no special logic)
+  t0: '2022-08-01'
   series:
     - time: t0
       vc: janssen1/1
-    - time: +P4W
-      vc: biontech2/2
   testCases:
     - time: janssen1/1
       assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.1
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: noch nicht vollständig
+        vaccinationState: PARTIAL_IMMUNIZATION
     - time: janssen1/1+P15D
       assertions:
         vaccinationState: PARTIAL_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 15 Tage
-            longText:
-              de: noch nicht vollständig
-    - time: biontech2/2
+    - time: janssen1/1+P29D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING # seq no 0.4
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung heute
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 15 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P1D
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: janssen1/1+P91D
       assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 1 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 14 Tagen wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P14D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_PENDING
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 14 Tag
-            longText:
-              de: Impfungen der Grundimmunisierung.*in 1 Tag wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P15D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.4 + 3.2
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 15 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-    - time: biontech2/2+P16D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            subtitleText:
-              de: Letzte Impfung vor 16 Tage
-            longText:
-              de: Impfungen der Grundimmunisierung.*Impfschutz ist wirksam.*empfohlene Auffrischimpfungen
-- description: rc + biontech1/1
-  t0: '2022-01-01'
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 0.2 - RC
+  t0: '2022-08-01'
   series:
     - time: t0
       rc: rc1
-    - time: +P6W
-      vc: biontech1/1
-  testCases:
-    - time: rc1
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.3 + 3.1
-    - time: biontech1/1
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.3 + 3.5
-- description: rc + janssen1/1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      rc: rc1
-    - time: +P6W
-      vc: janssen1/1
-  testCases:
-    - time: rc1
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.3
-    - time: rc1+P29D
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 3.1
-    - time: janssen1/1
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION # seq no 2.3 + 3.5
-- description: rc + biontech2/2
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      rc: rc1
-    - time: +P36W
-      vc: biontech2/2
-  testCases:
-    - time: biontech2/2
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.14
-- description: biontech2/2 + rc
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: biontech2/2
-    - time: +P36W
-      rc: rc1
-  testCases:
-    - time: rc1
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC_PENDING # seq no 2.8
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 252 Tage
-            longText:
-              de: Impfungen und durchgemachten Infektion.*in 29 Tagen vollständig.*noch ansteckend
-    - time: rc1+P28D
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC_PENDING # seq no 2.8
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 280 Tage
-            longText:
-              de: Impfungen und durchgemachten Infektion.*in 1 Tag vollständig.*noch ansteckend
-    - time: rc1+P29D
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC # seq no 3.15
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 281 Tage
-            longText:
-              de: Impfungen und durchgemachten Infektion.*keine weitere Impfung
-- description: janssen1/1 + rc1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: janssen1/1
-    - time: +P6W
-      rc: rc1
-  testCases:
-    - time: janssen1/1
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.1
-    - time: rc1
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING # seq no 0.2
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 42 Tage
-            longText:
-              de: Impfung und durchgemachten Infektion als grundimmunisiert.*in 29 Tagen wirksam
-    - time: rc1+P28D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING # seq no 0.2
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 70 Tage
-            longText:
-              de: Impfung und durchgemachten Infektion als grundimmunisiert.*in 1 Tag wirksam
-    - time: rc1+P29D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_RC # seq no 2.1 + 3.7
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: Letzte Impfung vor 71 Tage
-            longText:
-              de: Impfung und durchgemachten Infektion als grundimmunisiert.*empfohlene Auffrischimpfungen
-- description: biontech1/2 + rc1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: biontech1/2
-    - time: +P6W
-      rc: rc1
-  testCases:
-    - time: biontech1/2
-      assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 0.8
-    - time: rc1
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING # seq no 0.7
-    - time: rc1+P29D
-      assertions:
-        vaccinationState: COMPLETE_IMMUNIZATION_RC # seq no 2.2 + 3.6
-- description: biontech 2/1 + rc
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: biontech2/1
-    - time: +P4W
-      rc: rc1
-  testCases:
-    - time: biontech2/1
-      assertions:
-        # this is a bit illogical that with an additional event (e.g. rc 1)
-        # the user gets a worse vaccination state
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.10
-    - time: rc1
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC_PENDING # seq no 2.7
-    - time: rc1+P29D
-      assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC # seq no 3.9
-- description: rc + biontech 2/1
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      rc: rc1
-    - time: +P4W
-      vc: biontech2/1
   testCases:
     - time: rc1
       assertions:
         vaccinationState: PARTIAL_IMMUNIZATION
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: '' # empty string
-            longText:
-              de: noch nicht vollständig
-    - time: biontech2/1
+    - time: rc1+P15D
       assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.12
-- description: biontech 1/1 + biontech 2/2 (old notation)
-  t0: '2022-01-01'
-  series:
-    - time: t0
-      vc: biontech1/1
-    - time: +P4W
-      vc: biontech2/2
-  testCases:
-    - time: biontech2/2
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: rc1+P29D
       assertions:
-        vaccinationState: COMPLETE_BOOSTER # seq no 3.13
-- description: rat
-  t0: '2022-01-01'
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 1.1 - RAT test
+  t0: '2022-08-01'
   series:
     - time: t0
       tc: rat1
   testCases:
     - time: rat1
       assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 1.1
-        walletInfo:
-          vaccinationState:
-            visible: true
-            titleText:
-              de: Impfstatus
-            subtitleText:
-              de: '' # empty string
-            longText:
-              de: noch nicht vollständig
-- description: pcr
-  t0: '2022-01-01'
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: rat1+PT24H
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: rat1+PT24H1S
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 1.2 - PCR test
+  t0: '2022-08-01'
   series:
     - time: t0
       tc: pcr1
   testCases:
     - time: pcr1
       assertions:
-        vaccinationState: PARTIAL_IMMUNIZATION # seq no 1.2
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: pcr1+PT24H
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+    - time: pcr1+PT24H1S
+      assertions:
+        vaccinationState: PARTIAL_IMMUNIZATION
+
+- description: 2.1 - RC + VC 2/1
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      rc: rc1
+    - time: +P1M
+      vc: biontech2/1
+  testCases:
+    - time: biontech2/1
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/1+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/1+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/1+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/1
+      description: long text test
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+        walletInfo:
+          vaccinationState:
+            longText:
+              de: ^Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft\. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen\.$
+
+- description: 2.1 - RC + VC 2/2 (old notation)
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      rc: rc1
+    - time: +P1M
+      vc: biontech2/2
+  testCases:
+    - time: biontech2/2
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/2+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/2+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: biontech2/2+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+
+- description: 2.2 - VC 2/1 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech2/1
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+        walletInfo:
+          vaccinationState:
+            longText:
+              de: ^Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in 29 Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.$
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+        walletInfo:
+          vaccinationState:
+            longText:
+              de: ^Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in 14 Tagen wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.$
+    - time: rc1+P28D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+        walletInfo:
+          vaccinationState:
+            longText:
+              de: ^Sie gelten aufgrund Ihrer Impfung und durchgemachten Infektion als vollständig geimpft. Allerdings ist Ihr Immunschutz erst in 1 Tag wirksam. Bitte bedenken Sie, dass Sie noch ansteckend sein können und informieren Sie sich aber auch über empfohlene Auffrischimpfungen.$
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+
+- description: 2.2 - VC 2/2 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech2/2
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+    - time: rc1+P28D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC_PENDING
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION_RC
+
+- description: 2.3 - VC 3/1
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech3/1
+  testCases:
+    - time: biontech3/1
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/1+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/1+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/1+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/1
+      description: long text test
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+        walletInfo:
+          vaccinationState:
+            longText:
+              de: ^Sie haben alle Impfungen für einen vollständigen Impfschutz erhalten\. Ihr Impfschutz ist wirksam\. Bitte informieren Sie sich aber auch über empfohlene Auffrischimpfungen\.$
+
+- description: 2.3 - VC 3/3
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech3/3
+  testCases:
+    - time: biontech3/3
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/3+P15D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/3+P29D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+    - time: biontech3/3+P91D
+      assertions:
+        vaccinationState: COMPLETE_IMMUNIZATION
+
+- description: 2.4 - VC 3/1 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech3/1
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: 2.4 - VC 3/3 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech3/3
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: 2.5 - VC 4/1
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech4/1
+  testCases:
+    - time: biontech4/1
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/1+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/1+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/1+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: 2.5 - VC 4/4
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech4/4
+  testCases:
+    - time: biontech4/4
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/4+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/4+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: biontech4/4+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: 2.6 - VC 4/1 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech4/1
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: 2.6 - VC 4/4 + RC
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      vc: biontech4/4
+    - time: +P1M
+      rc: rc1
+  testCases:
+    - time: rc1
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P15D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P29D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+    - time: rc1+P91D
+      assertions:
+        vaccinationState: COMPLETE_BOOSTER
+
+- description: general texts
+  t0: '2022-08-01'
+  series:
+    - time: t0
+      tc: rat1
+  testCases:
+    - time: rat1
+      assertions:
         walletInfo:
           vaccinationState:
             visible: true
             titleText:
               de: Impfstatus
-            subtitleText:
-              de: '' # empty string
-            longText:
-              de: noch nicht vollständig
-- description: EXPOSUREAPP-12623 - incorrect vaccination status for 1/2 + 2/2 + rc
-  t0: '2022-01-01'
+- description: subtitle text basics
+  t0: '2022-08-01'
   series:
-    - time: t0+P-180D
-      vc: biontech1/2
-    - time: t0+P-130D
-      vc: biontech2/2
-    - time: t0+P-50D
-      rc: rc1
-  testCases:
     - time: t0
+      tc: rat1
+    - time: +P1M
+      tc: pcr1
+    - time: +P1M
+      rc: rc1
+    - time: +P1M
+      vc: biontech1/1
+    - time: +P1M
+      vc: biontech2/1
+  testCases:
+    - time: rat1
       assertions:
-        vaccinationState: COMPLETE_BOOSTER_RC
         walletInfo:
-            longText:
-              de: Derzeit wird keine weitere Impfung empfohlen
+          vaccinationState:
+            subtitleText:
+              de: ^$ # empty
+    - time: pcr1
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^$ # empty
+    - time: rc1
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^$ # empty
+    - time: biontech1/1
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung heute$
+    - time: biontech1/1+P1D
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung vor 1 Tag$
+    - time: biontech1/1+P2D
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung vor 2 Tagen$
+    - time: biontech2/1
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung heute$
+    - time: biontech2/1+P1D
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung vor 1 Tag$
+    - time: biontech2/1+P2D
+      assertions:
+        walletInfo:
+          vaccinationState:
+            subtitleText:
+              de: ^Letzte Impfung vor 2 Tagen$


### PR DESCRIPTION
This PR updates the logic and texts for determining the vaccination state (see also #101) based on the updated IfSG that becomes effective Oct 1, 2022.

From https://github.com/corona-warn-app/cwa-app-ccl/pull/107/commits/c01468fd8a03a998d9f50d4063d41a78f08373e0:

> there are now the following states:
> 
> - COMPLETE_IMMUNIZATION for anything that is full immunization based on
> IfSG (e.g. 3 shots) and where the last event is not a recovery
> - COMPLETE_IMMUNIZATION_RC for anything that is full immunization based
> on IfSG (e.g. 2 shots + recovery) and where the last event is not a
> recovery
> - COMPLETE_IMMUNIZATION_RC_PENDING for anything that matches
> COMPLETE_IMMUNIZATION_RC within the first 29 days
> - COMPLETE_BOOSTER for anything that is beyond COMPLETE_IMMUNIZATION or
> COMPLETE_IMMUNIZATION_RC
> - PARTIAL_IMMUNIZATION for anything else