### PR TITLE
Feature: Hide mask state by default (EXPOSUREAPP-13915)

### DIFF
--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -1883,6 +1883,12 @@ const descriptor = {
               },
               // basic
               {
+                in: [
+                  { var: 'scenarioIdentifier' },
+                  [...constants.FEDERAL_STATE_IDS, 'DE', 'BASIC']
+                ]
+              },
+              {
                 if: [
                   {
                     or: [
@@ -1893,7 +1899,9 @@ const descriptor = {
                   'MASK_OPTIONAL',
                   'MASK_REQUIRED'
                 ]
-              }
+              },
+              // else
+              'OTHER'
             ]
           }
         ]

--- a/lib/ccl/functions/__analyzeDccWallet.js
+++ b/lib/ccl/functions/__analyzeDccWallet.js
@@ -1835,6 +1835,13 @@ const descriptor = {
           {
             if: [
               {
+                in: [
+                  { var: 'scenarioIdentifier' },
+                  ['NO_SELECTION', 'NO_MANDATE']
+                ]
+              },
+              { var: 'scenarioIdentifier' },
+              {
                 '===': [
                   { var: 'scenarioIdentifier' },
                   'EXTENDED'

--- a/lib/ccl/functions/getDccAdmissionCheckScenarios.js
+++ b/lib/ccl/functions/getDccAdmissionCheckScenarios.js
@@ -1,5 +1,5 @@
 const scenarios = [
-  { identifier: 'DE', subtitle: true, enabled: true },
+  { identifier: 'NO_SELECTION', subtitle: false, enabled: true },
   { identifier: 'BW', subtitle: false, enabled: false },
   { identifier: 'BY', subtitle: false, enabled: false },
   { identifier: 'BE', subtitle: false, enabled: false },

--- a/lib/ccl/functions/getDccWalletInfo.js
+++ b/lib/ccl/functions/getDccWalletInfo.js
@@ -107,31 +107,25 @@ const descriptor = {
           {
             init: [
               'object',
-              'identifier', { var: 'walletAnalysis.maskState' },
+              'identifier', {
+                if: [
+                  {
+                    in: [
+                      { var: 'walletAnalysis.maskState' },
+                      ['MASK_REQUIRED', 'MASK_OPTIONAL']
+                    ]
+                  },
+                  { var: 'walletAnalysis.maskState' },
+                  'OTHER'
+                ]
+              },
               'faqAnchor', 'mask_rules',
               'visible', {
                 in: [
                   { var: 'walletAnalysis.maskState' },
-                  ['MASK_REQUIRED', 'MASK_OPTIONAL']
+                  ['MASK_REQUIRED', 'MASK_OPTIONAL', 'NO_SELECTION', 'NO_MANDATE']
                 ]
               }
-            ]
-          }
-        ]
-      },
-      {
-        declare: [
-          'maskStateScenarioTextKeyComponent',
-          {
-            if: [
-              {
-                in: [
-                  { var: 'scenarioIdentifier' },
-                  constants.FEDERAL_STATE_IDS
-                ]
-              },
-              { var: 'scenarioIdentifier' },
-              'DE' // default value
             ]
           }
         ]
@@ -150,7 +144,7 @@ const descriptor = {
                       concatenate: [
                         'MASK_STATE_',
                         { var: 'walletAnalysis.maskState' },
-                        '_TITLE_TEXT' // reuse title text
+                        '_BADGE_TEXT'
                       ]
                     }
                   }
@@ -171,15 +165,37 @@ const descriptor = {
                   '__i18n.getTextDescriptor',
                   {
                     key: {
-                      concatenate: [
-                        'MASK_STATE_',
-                        { var: 'walletAnalysis.maskState' },
-                        '_TITLE_TEXT'
+                      if: [
+                        {
+                          '===': [
+                            { var: 'walletAnalysis.maskState' },
+                            'MASK_OPTIONAL'
+                          ]
+                        },
+                        'MASK_STATE_MASK_OPTIONAL_TITLE_TEXT',
+                        'MASK_STATE_DEFAULT_TITLE_TEXT'
                       ]
                     }
                   }
                 ]
               }
+            ]
+          }
+        ]
+      },
+      {
+        declare: [
+          'maskStateSubtitleScenarioTextKeyComponent',
+          {
+            if: [
+              {
+                in: [
+                  { var: 'scenarioIdentifier' },
+                  [...constants.FEDERAL_STATE_IDS, 'NO_SELECTION']
+                ]
+              },
+              { var: 'scenarioIdentifier' },
+              'EMPTY'
             ]
           }
         ]
@@ -197,7 +213,7 @@ const descriptor = {
                     key: {
                       concatenate: [
                         'ADMISSION_SCENARIO_SELECTION_',
-                        { var: 'maskStateScenarioTextKeyComponent' },
+                        { var: 'maskStateSubtitleScenarioTextKeyComponent' },
                         '_TITLE_TEXT'
                       ]
                     }
@@ -240,8 +256,7 @@ const descriptor = {
                       concatenate: [
                         'MASK_STATE_',
                         { var: 'walletAnalysis.maskState' },
-                        '_LONG_TEXT_',
-                        { var: 'maskStateScenarioTextKeyComponentLongText' }
+                        '_LONG_TEXT'
                       ]
                     }
                   }

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -6,6 +6,8 @@
   <!-- XTXT: Admission Scenario - Card Subtitle Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_TITLE_TEXT">"Ihr Bundesland"</string>
 
+  <!-- XTXT: Admission Scenario - EMPTY Title Text -->
+  <string name="ADMISSION_SCENARIO_SELECTION_EMPTY_TITLE_TEXT">""</string>
   <!-- XTXT: Admission Scenario - NO_SELECTION Title Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_NO_SELECTION_TITLE_TEXT">"keine Auswahl"</string>
   <!-- XTXT: Admission Scenario - BW Title Text -->
@@ -114,8 +116,10 @@
   <!-- XTXT: DCC Reissuance for extension - Consent - Subtitle Text -->
   <string name="DCC_REISSUANCE_CONSENT_SUBTITLE_TEXT_EXTEND">"Erneuerung direkt über die App vornehmen"</string>
 
-  <!-- XHED: Mask State - Card Title -->
-  <string name="MASK_STATE_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XHED: Mask State - Default Card Title -->
+  <string name="MASK_STATE_DEFAULT_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XHED: Mask State - MASK_OPTIONAL - Card Title -->
+  <string name="MASK_STATE_MASK_OPTIONAL_TITLE_TEXT">"Keine Maskenpflicht"</string>
 
   <!-- XTXT: Mask State - MASK_REQUIRED Badge Text -->
   <string name="MASK_STATE_MASK_REQUIRED_BADGE_TEXT">"Maskenpflicht"</string>

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -6,11 +6,6 @@
   <!-- XTXT: Admission Scenario - Card Subtitle Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_TITLE_TEXT">"Ihr Bundesland"</string>
 
-  <!-- XTXT: Admission Scenario - DE Title Text -->
-  <string name="ADMISSION_SCENARIO_SELECTION_DE_TITLE_TEXT">"Regeln des Bundes"</string>
-  <!-- XTXT: Admission Scenario - DE Subtitle Text -->
-  <string name="ADMISSION_SCENARIO_SELECTION_DE_SUBTITLE_TEXT">"Regeln in Ihrem Bundesland können davon abweichen"</string>
-
   <!-- XTXT: Admission Scenario - NO_SELECTION Title Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_NO_SELECTION_TITLE_TEXT">"keine Auswahl"</string>
   <!-- XTXT: Admission Scenario - BW Title Text -->

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -119,23 +119,26 @@
   <!-- XTXT: DCC Reissuance for extension - Consent - Subtitle Text -->
   <string name="DCC_REISSUANCE_CONSENT_SUBTITLE_TEXT_EXTEND">"Erneuerung direkt über die App vornehmen"</string>
 
-  <!-- XHED: Mask State - MASK_REQUIRED Card Title -->
-  <string name="MASK_STATE_MASK_REQUIRED_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XHED: Mask State - Card Title -->
+  <string name="MASK_STATE_TITLE_TEXT">"Maskenpflicht"</string>
+
+  <!-- XTXT: Mask State - MASK_REQUIRED Badge Text -->
+  <string name="MASK_STATE_MASK_REQUIRED_BADGE_TEXT">"Maskenpflicht"</string>
   <!-- XTXT: Mask State - MASK_REQUIRED Card Body -->
   <string name="MASK_STATE_MASK_REQUIRED_LONG_TEXT">"Sie sind in diesem Bundesland nicht von der Maskenpflicht ausgenommen.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 
-  <!-- XHED: Mask State - MASK_OPTIONAL Card Title -->
-  <string name="MASK_STATE_MASK_OPTIONAL_TITLE_TEXT">"Keine Maskenpflicht"</string>
+  <!-- XTXT: Mask State - MASK_OPTIONAL Badge Text -->
+  <string name="MASK_STATE_MASK_OPTIONAL_BADGE_TEXT">"Keine Maskenpflicht"</string>
   <!-- XTXT: Mask State - MASK_OPTIONAL Card Body -->
   <string name="MASK_STATE_MASK_OPTIONAL_LONG_TEXT">"Sie sind in diesem Bundesland in einigen Situationen von der Maskenpflicht ausgenommen; eine Maske ist dennoch empfohlen.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 
-  <!-- XHED: Mask State - NO_SELECTION Card Title -->
-  <string name="MASK_STATE_NO_SELECTION_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XTXT: Mask State - NO_SELECTION Badge Text -->
+  <string name="MASK_STATE_NO_SELECTION_BADGE_TEXT">""</string>
   <!-- XTXT: Mask State - NO_SELECTION Card Body -->
   <string name="MASK_STATE_NO_SELECTION_LONG_TEXT">"Ohne Auswahl eines Bundeslandes kann Ihnen nicht angezeigt werden, ob Sie von einer bundeslandspezifischen Maskenpflicht ausgenommen sind.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 
-  <!-- XHED: Mask State - NO_MANDATE Card Title -->
-  <string name="MASK_STATE_NO_MANDATE_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XTXT: Mask State - NO_MANDATE Badge Text -->
+  <string name="MASK_STATE_NO_MANDATE_BADGE_TEXT">""</string>
   <!-- XTXT: Mask State - NO_MANDATE Card Body -->
   <string name="MASK_STATE_NO_MANDATE_LONG_TEXT">"Für dieses Bundesland liegen keine bundeslandspezifischen Regeln vor. Es gelten daher nur die bundeseinheitlichen Regeln zur Maskenpflicht.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 

--- a/resources/i18n/de/strings.xml
+++ b/resources/i18n/de/strings.xml
@@ -11,6 +11,8 @@
   <!-- XTXT: Admission Scenario - DE Subtitle Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_DE_SUBTITLE_TEXT">"Regeln in Ihrem Bundesland können davon abweichen"</string>
 
+  <!-- XTXT: Admission Scenario - NO_SELECTION Title Text -->
+  <string name="ADMISSION_SCENARIO_SELECTION_NO_SELECTION_TITLE_TEXT">"keine Auswahl"</string>
   <!-- XTXT: Admission Scenario - BW Title Text -->
   <string name="ADMISSION_SCENARIO_SELECTION_BW_TITLE_TEXT">"Baden-Württemberg"</string>
   <!-- XTXT: Admission Scenario - BY Title Text -->
@@ -119,16 +121,22 @@
 
   <!-- XHED: Mask State - MASK_REQUIRED Card Title -->
   <string name="MASK_STATE_MASK_REQUIRED_TITLE_TEXT">"Maskenpflicht"</string>
-  <!-- XTXT: Mask State - MASK_REQUIRED Card Body - Federal default rules -->
-  <string name="MASK_STATE_MASK_REQUIRED_LONG_TEXT_BASIC">"Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden."</string>
-  <!-- XTXT: Mask State - MASK_REQUIRED Card Body - Extended federal state-specific rules -->
-  <string name="MASK_STATE_MASK_REQUIRED_LONG_TEXT_EXTENDED">"Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden."</string>
+  <!-- XTXT: Mask State - MASK_REQUIRED Card Body -->
+  <string name="MASK_STATE_MASK_REQUIRED_LONG_TEXT">"Sie sind in diesem Bundesland nicht von der Maskenpflicht ausgenommen.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 
   <!-- XHED: Mask State - MASK_OPTIONAL Card Title -->
   <string name="MASK_STATE_MASK_OPTIONAL_TITLE_TEXT">"Keine Maskenpflicht"</string>
-  <!-- XTXT: Mask State - MASK_OPTIONAL Card Body - Federal default rules -->
-  <string name="MASK_STATE_MASK_OPTIONAL_LONG_TEXT_BASIC">"Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden."</string>
-  <!-- XTXT: Mask State - MASK_OPTIONAL Card Body - Extended federal state-specific rules -->
-  <string name="MASK_STATE_MASK_OPTIONAL_LONG_TEXT_EXTENDED">"Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden."</string>
+  <!-- XTXT: Mask State - MASK_OPTIONAL Card Body -->
+  <string name="MASK_STATE_MASK_OPTIONAL_LONG_TEXT">"Sie sind in diesem Bundesland in einigen Situationen von der Maskenpflicht ausgenommen; eine Maske ist dennoch empfohlen.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
+
+  <!-- XHED: Mask State - NO_SELECTION Card Title -->
+  <string name="MASK_STATE_NO_SELECTION_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XTXT: Mask State - NO_SELECTION Card Body -->
+  <string name="MASK_STATE_NO_SELECTION_LONG_TEXT">"Ohne Auswahl eines Bundeslandes kann Ihnen nicht angezeigt werden, ob Sie von einer bundeslandspezifischen Maskenpflicht ausgenommen sind.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
+
+  <!-- XHED: Mask State - NO_MANDATE Card Title -->
+  <string name="MASK_STATE_NO_MANDATE_TITLE_TEXT">"Maskenpflicht"</string>
+  <!-- XTXT: Mask State - NO_MANDATE Card Body -->
+  <string name="MASK_STATE_NO_MANDATE_LONG_TEXT">"Für dieses Bundesland liegen keine bundeslandspezifischen Regeln vor. Es gelten daher nur die bundeseinheitlichen Regeln zur Maskenpflicht.\n\nHinweis:\nSofern das Bundesland, in dem Sie sich aufhalten, eine Maskenpflicht angeordnet hat, befreit Sie ein negativer Schnell- oder PCR-Test bei Freizeit-, Kultur- und Sportveranstaltungen sowie in gastronomischen Einrichtungen für 24 Stunden von dieser Maskenpflicht. Ein unbeaufsichtigt durchgeführter Selbsttest genügt nicht. Ihr Bundesland kann regeln, dass Sie auch durch Impfungen oder Genesung (wenn diese höchstens drei Monate zurückliegen) von der Maskenpflicht befreit sind. Eine Befreiung von der Maskenpflicht gilt nicht im öffentlichen Personenfernverkehr, in Krankenhäusern, Pflegeeinrichtungen und für Patientinnen und Patienten in Arztpraxen.\n\nSollten Ihre in der App hinterlegten COVID-Zertifikate ausreichen, um Sie in Ihrem Bundesland von der Maskenpflicht zu befreien, färbt sich Ihr Zertifikat grün. Ihre Befreiung von der Maskenpflicht in Ihrem Bundesland kann durch einen Scan Ihres QR-Codes mithilfe der CovPassCheck-App nachgewiesen werden."</string>
 
 </resources>

--- a/test/fixtures/ccl/ccl-admission-check-scenarios.yaml
+++ b/test/fixtures/ccl/ccl-admission-check-scenarios.yaml
@@ -1,4 +1,4 @@
-- description: scenarios info for identifiers DE, BW, HH and languageCode DE
+- description: scenarios info contains list of federal states
   assertions:
     labelText:
       de: ^Maskenpflichtregelung für:$
@@ -6,11 +6,9 @@
       titleText:
         de: Ihr Bundesland
       items:
-        - identifier: DE
+        - identifier: NO_SELECTION
           titleText:
-            de: Regeln des Bundes
-          subtitleText:
-            de: Regeln in Ihrem Bundesland können davon abweichen
+            de: keine Auswahl
           enabled: true
         - identifier: BW
           titleText:

--- a/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
@@ -4,6 +4,16 @@
     - time: t0
       vc: biontech1/2
   testCases:
+    # default
+    - time: biontech1/2
+      assertions:
+        maskState: OTHER
+    - time: biontech1/2+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech1/2+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech1/2
       scenarioIdentifier: BASIC
@@ -33,11 +43,20 @@
 
 - description: 0.1 - VC 2/2
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech2/2
   testCases:
+    # default
+    - time: biontech2/2
+      assertions:
+        maskState: OTHER
+    - time: biontech2/2+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech2/2+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech2/2
       scenarioIdentifier: BASIC
@@ -67,11 +86,20 @@
 
 - description: 0.1 - VC 2/1
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech2/1
   testCases:
+    # default
+    - time: biontech2/1
+      assertions:
+        maskState: OTHER
+    - time: biontech2/1+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech2/1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech2/1
       scenarioIdentifier: BASIC
@@ -101,11 +129,20 @@
 
 - description: 0.1 - VC 1/1
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech1/1
   testCases:
+    # default
+    - time: biontech1/1
+      assertions:
+        maskState: OTHER
+    - time: biontech1/1+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech1/1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech1/1
       scenarioIdentifier: BASIC
@@ -135,11 +172,26 @@
 
 - description: 0.2 - RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -185,11 +237,20 @@
 
 - description: 1.1 - RAT test - MASK_OPTIONAL within 24 hours, MASK_REQUIRED otherwise
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       tc: rat1
   testCases:
+    # default
+    - time: rat1
+      assertions:
+        maskState: OTHER
+    - time: rat1+PT24H
+      assertions:
+        maskState: OTHER
+    - time: rat1+PT24H1S
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rat1
       scenarioIdentifier: BASIC
@@ -219,11 +280,20 @@
 
 - description: 1.2 - PCR test - MASK_OPTIONAL within 24 hours, MASK_REQUIRED otherwise
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       tc: pcr1
   testCases:
+    # default
+    - time: pcr1
+      assertions:
+        maskState: OTHER
+    - time: pcr1+PT24H
+      assertions:
+        maskState: OTHER
+    - time: pcr1+PT24H1S
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: pcr1
       scenarioIdentifier: BASIC
@@ -253,13 +323,22 @@
 
 - description: 2.1 - RC + VC 2/1
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       rc: rc1
     - time: +P1M
       vc: biontech2/1
   testCases:
+    # default
+    - time: biontech2/1
+      assertions:
+        maskState: OTHER
+    - time: biontech2/1+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech2/1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech2/1
       scenarioIdentifier: BASIC
@@ -289,13 +368,22 @@
 
 - description: 2.1 - RC + VC 2/2 (old notation)
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       rc: rc1
     - time: +P1M
       vc: biontech2/2
   testCases:
+    # default
+    - time: biontech2/2
+      assertions:
+        maskState: OTHER
+    - time: biontech2/2+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech2/2+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech2/2
       scenarioIdentifier: BASIC
@@ -325,13 +413,28 @@
 
 - description: 2.2 - VC 2/1 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech2/1
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -377,13 +480,28 @@
 
 - description: 2.2 - VC 2/2 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech2/2
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -429,11 +547,20 @@
 
 - description: 2.3 - VC 3/1
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech3/1
   testCases:
+    # default
+    - time: biontech3/1
+      assertions:
+        maskState: OTHER
+    - time: biontech3/1+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech3/1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech3/1
       scenarioIdentifier: BASIC
@@ -463,11 +590,20 @@
 
 - description: 2.3 - VC 3/3
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech3/3
   testCases:
+    # default
+    - time: biontech3/3
+      assertions:
+        maskState: OTHER
+    - time: biontech3/3+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech3/3+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech3/3
       scenarioIdentifier: BASIC
@@ -497,13 +633,28 @@
 
 - description: 2.4 - VC 3/1 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech3/1
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -549,13 +700,28 @@
 
 - description: 2.4 - VC 3/3 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech3/3
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -601,11 +767,20 @@
 
 - description: 2.5 - VC 4/1
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech4/1
   testCases:
+    # default
+    - time: biontech4/1
+      assertions:
+        maskState: OTHER
+    - time: biontech4/1+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech4/1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech4/1
       scenarioIdentifier: BASIC
@@ -635,11 +810,20 @@
 
 - description: 2.5 - VC 4/4
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech4/4
   testCases:
+    # default
+    - time: biontech4/4
+      assertions:
+        maskState: OTHER
+    - time: biontech4/4+P90D
+      assertions:
+        maskState: OTHER
+    - time: biontech4/4+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: biontech4/4
       scenarioIdentifier: BASIC
@@ -669,13 +853,28 @@
 
 - description: 2.6 - VC 4/1 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech4/1
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -721,13 +920,28 @@
 
 - description: 2.6 - VC 4/4 + RC
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       vc: biontech4/4
     - time: +P1M
       rc: rc1
   testCases:
+    # default
+    - time: rc1
+      assertions:
+        maskState: OTHER
+    - time: rc1+P28D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P29D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P90D
+      assertions:
+        maskState: OTHER
+    - time: rc1+P91D
+      assertions:
+        maskState: OTHER
     # basic federal state-specific rules
     - time: rc1
       scenarioIdentifier: BASIC
@@ -773,29 +987,30 @@
 
 - description: texts
   t0: '2022-08-01'
-  only: true
   series:
     - time: t0
       tc: rat1
   testCases:
+    # default
     - time: rat1
       assertions:
-        maskState: MASK_OPTIONAL
+        maskState: OTHER
         walletInfo:
           maskState:
-            identifier: MASK_OPTIONAL
-            visible: true
-            faqAnchor: mask_rules
-            titleText:
-              de: Keine Maskenpflicht
-            badgeText:
-              de: Keine Maskenpflicht
+            identifier: OTHER
+            visible: false
     # basic federal state-specific rules
     - time: rat1
       scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Keine Maskenpflicht
+            badgeText:
+              de: Keine Maskenpflicht
             longText:
               de: 'Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # extended federal state-specific rules
@@ -804,6 +1019,12 @@
       assertions:
         walletInfo:
           maskState:
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Keine Maskenpflicht
+            badgeText:
+              de: Keine Maskenpflicht
             longText:
               de: 'Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # scenario-dependent subtitle
@@ -933,24 +1154,26 @@
           maskState:
             subtitleText:
               de: ^Thüringen$
+    # default
     - time: rat1+P5D # some long duration
       assertions:
-        maskState: MASK_REQUIRED
+        maskState: OTHER
         walletInfo:
           maskState:
-            identifier: MASK_REQUIRED
-            visible: true
-            faqAnchor: mask_rules
-            titleText:
-              de: Maskenpflicht
-            badgeText:
-              de: Maskenpflicht
+            identifier: OTHER
+            visible: false
     # basic federal state-specific rules
     - time: rat1+P5D # some long duration
       scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Maskenpflicht
+            badgeText:
+              de: Maskenpflicht
             longText:
               de: 'Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # extended federal state-specific rules
@@ -959,6 +1182,12 @@
       assertions:
         walletInfo:
           maskState:
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Maskenpflicht
+            badgeText:
+              de: Maskenpflicht
             longText:
               de: 'Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # scenario-dependent subtitle

--- a/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
@@ -4,14 +4,17 @@
     - time: t0
       vc: biontech1/2
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech1/2
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech1/2+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech1/2+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -30,18 +33,22 @@
 
 - description: 0.1 - VC 2/2
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech2/2
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech2/2
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/2+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/2+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -60,18 +67,22 @@
 
 - description: 0.1 - VC 2/1
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech2/1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech2/1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -90,18 +101,22 @@
 
 - description: 0.1 - VC 1/1
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech1/1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech1/1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech1/1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech1/1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -120,24 +135,30 @@
 
 - description: 0.2 - RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -164,18 +185,22 @@
 
 - description: 1.1 - RAT test - MASK_OPTIONAL within 24 hours, MASK_REQUIRED otherwise
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       tc: rat1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rat1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_OPTIONAL
     - time: rat1+PT24H
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_OPTIONAL
     - time: rat1+PT24H1S
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -194,18 +219,22 @@
 
 - description: 1.2 - PCR test - MASK_OPTIONAL within 24 hours, MASK_REQUIRED otherwise
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       tc: pcr1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: pcr1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_OPTIONAL
     - time: pcr1+PT24H
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_OPTIONAL
     - time: pcr1+PT24H1S
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -224,20 +253,24 @@
 
 - description: 2.1 - RC + VC 2/1
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       rc: rc1
     - time: +P1M
       vc: biontech2/1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech2/1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -256,20 +289,24 @@
 
 - description: 2.1 - RC + VC 2/2 (old notation)
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       rc: rc1
     - time: +P1M
       vc: biontech2/2
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech2/2
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/2+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech2/2+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -288,26 +325,32 @@
 
 - description: 2.2 - VC 2/1 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech2/1
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -334,26 +377,32 @@
 
 - description: 2.2 - VC 2/2 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech2/2
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -380,18 +429,22 @@
 
 - description: 2.3 - VC 3/1
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech3/1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech3/1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech3/1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech3/1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -410,18 +463,22 @@
 
 - description: 2.3 - VC 3/3
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech3/3
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech3/3
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech3/3+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech3/3+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -440,26 +497,32 @@
 
 - description: 2.4 - VC 3/1 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech3/1
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -486,26 +549,32 @@
 
 - description: 2.4 - VC 3/3 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech3/3
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -532,18 +601,22 @@
 
 - description: 2.5 - VC 4/1
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech4/1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech4/1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech4/1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech4/1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -562,18 +635,22 @@
 
 - description: 2.5 - VC 4/4
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech4/4
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: biontech4/4
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech4/4+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: biontech4/4+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -592,26 +669,32 @@
 
 - description: 2.6 - VC 4/1 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech4/1
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -638,26 +721,32 @@
 
 - description: 2.6 - VC 4/4 + RC
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       vc: biontech4/4
     - time: +P1M
       rc: rc1
   testCases:
-    # federal default rules
+    # basic federal state-specific rules
     - time: rc1
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P28D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P29D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P90D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     - time: rc1+P91D
+      scenarioIdentifier: BASIC
       assertions:
         maskState: MASK_REQUIRED
     # extended federal state-specific rules
@@ -684,6 +773,7 @@
 
 - description: texts
   t0: '2022-08-01'
+  only: true
   series:
     - time: t0
       tc: rat1
@@ -700,9 +790,9 @@
               de: Keine Maskenpflicht
             badgeText:
               de: Keine Maskenpflicht
-    # federal default rules
+    # basic federal state-specific rules
     - time: rat1
-      scenarioIdentifier: ''
+      scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
@@ -718,7 +808,7 @@
               de: 'Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # scenario-dependent subtitle
     - time: rat1
-      scenarioIdentifier: ''
+      scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
@@ -855,9 +945,9 @@
               de: Maskenpflicht
             badgeText:
               de: Maskenpflicht
-    # federal default rules
+    # basic federal state-specific rules
     - time: rat1+P5D # some long duration
-      scenarioIdentifier: ''
+      scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
@@ -873,14 +963,14 @@
               de: 'Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
     # scenario-dependent subtitle
     - time: rat1+P5D # some long duration
-      scenarioIdentifier: ''
+      scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:
             subtitleText:
               de: ^Regeln des Bundes$
     - time: rat1+P5D # some long duration
-      scenarioIdentifier: ''
+      scenarioIdentifier: BASIC
       assertions:
         walletInfo:
           maskState:

--- a/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
+++ b/test/fixtures/ccl/dcc-series-wallet-info-mask-state.yaml
@@ -991,7 +991,7 @@
     - time: t0
       tc: rat1
   testCases:
-    # default
+    # default, no scenario selection (implicit)
     - time: rat1
       assertions:
         maskState: OTHER
@@ -999,26 +999,64 @@
           maskState:
             identifier: OTHER
             visible: false
-    # basic federal state-specific rules
+    # NO_SELECTION (explicit; M1)
     - time: rat1
-      scenarioIdentifier: BASIC
+      scenarioIdentifier: NO_SELECTION
       assertions:
+        maskState: NO_SELECTION
         walletInfo:
           maskState:
+            identifier: OTHER
             visible: true
             faqAnchor: mask_rules
             titleText:
-              de: Keine Maskenpflicht
+              de: Maskenpflicht
+            subtitleText:
+              de: ^keine Auswahl$
+            badgeText:
+              de: ^$ #empty
+            longText:
+              de: 'Ohne Auswahl eines Bundeslandes kann Ihnen nicht angezeigt werden, ob Sie von einer bundeslandspezifischen Maskenpflicht ausgenommen sind\.'
+    # NO_MANDATE (M2)
+    - time: rat1
+      scenarioIdentifier: NO_MANDATE
+      assertions:
+        maskState: NO_MANDATE
+        walletInfo:
+          maskState:
+            identifier: OTHER
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Maskenpflicht
+            badgeText:
+              de: ^$ #empty
+            longText:
+              de: 'Für dieses Bundesland liegen keine bundeslandspezifischen Regeln vor\. Es gelten daher nur die bundeseinheitlichen Regeln zur Maskenpflicht\.'
+    # MASK_OPTIONAL for basic federal state-specific rules (M4)
+    - time: rat1
+      scenarioIdentifier: BASIC
+      assertions:
+        maskState: MASK_OPTIONAL
+        walletInfo:
+          maskState:
+            identifier: MASK_OPTIONAL
+            visible: true
+            faqAnchor: mask_rules
+            titleText:
+              de: Maskenpflicht
             badgeText:
               de: Keine Maskenpflicht
             longText:
-              de: 'Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden.'
-    # extended federal state-specific rules
+              de: 'Sie sind in diesem Bundesland in einigen Situationen von der Maskenpflicht ausgenommen; eine Maske ist dennoch empfohlen\.'
+    # MASK_OPTIONAL for extended federal state-specific rules (M4)
     - time: rat1
       scenarioIdentifier: EXTENDED
       assertions:
+        maskState: MASK_OPTIONAL
         walletInfo:
           maskState:
+            identifier: MASK_OPTIONAL
             visible: true
             faqAnchor: mask_rules
             titleText:
@@ -1026,22 +1064,8 @@
             badgeText:
               de: Keine Maskenpflicht
             longText:
-              de: 'Sie sind von der Maskenpflicht ausgenommen, eine Maske ist dennoch empfohlen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
+              de: 'Sie sind in diesem Bundesland in einigen Situationen von der Maskenpflicht ausgenommen; eine Maske ist dennoch empfohlen\.'
     # scenario-dependent subtitle
-    - time: rat1
-      scenarioIdentifier: BASIC
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Regeln des Bundes$
-    - time: rat1
-      scenarioIdentifier: DE
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Regeln des Bundes$
     - time: rat1
       scenarioIdentifier: BW
       assertions:
@@ -1154,20 +1178,14 @@
           maskState:
             subtitleText:
               de: ^Thüringen$
-    # default
-    - time: rat1+P5D # some long duration
-      assertions:
-        maskState: OTHER
-        walletInfo:
-          maskState:
-            identifier: OTHER
-            visible: false
-    # basic federal state-specific rules
+    # MASK_REQUIRED for basic federal state-specific rules (M4)
     - time: rat1+P5D # some long duration
       scenarioIdentifier: BASIC
       assertions:
+        maskState: MASK_REQUIRED
         walletInfo:
           maskState:
+            identifier: MASK_REQUIRED
             visible: true
             faqAnchor: mask_rules
             titleText:
@@ -1175,13 +1193,15 @@
             badgeText:
               de: Maskenpflicht
             longText:
-              de: 'Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 24 Stunden negativ getestet wurden.'
-    # extended federal state-specific rules
+              de: 'Sie sind in diesem Bundesland nicht von der Maskenpflicht ausgenommen\.'
+    # MASK_REQUIRED for extended federal state-specific rules (M4)
     - time: rat1+P5D # some long duration
       scenarioIdentifier: EXTENDED
       assertions:
+        maskState: MASK_REQUIRED
         walletInfo:
           maskState:
+            identifier: MASK_REQUIRED
             visible: true
             faqAnchor: mask_rules
             titleText:
@@ -1189,138 +1209,4 @@
             badgeText:
               de: Maskenpflicht
             longText:
-              de: 'Sie sind nicht von der Maskenpflicht ausgenommen.\n\nVon der Maskenpflicht sind alle Personen ausgenommen, die innerhalb der letzten 90 Tage geimpft wurden oder genesen sind oder innerhalb der letzten 24 Stunden negativ getestet wurden.'
-    # scenario-dependent subtitle
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BASIC
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Regeln des Bundes$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BASIC
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Regeln des Bundes$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: DE
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Regeln des Bundes$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BW
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Baden-Württemberg$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BY
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Bayern$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BE
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Berlin$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: BB
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Brandenburg$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: HB
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Bremen$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: HH
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Hamburg$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: HE
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Hessen$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: MV
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Mecklenburg-Vorpommern$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: NI
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Niedersachsen$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: NW
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Nordrhein-Westfalen$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: RP
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Rheinland-Pfalz$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: SL
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Saarland$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: SN
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Sachsen$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: ST
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Sachsen-Anhalt$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: SH
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Schleswig-Holstein$
-    - time: rat1+P5D # some long duration
-      scenarioIdentifier: TH
-      assertions:
-        walletInfo:
-          maskState:
-            subtitleText:
-              de: ^Thüringen$
+              de: 'Sie sind in diesem Bundesland nicht von der Maskenpflicht ausgenommen\.'


### PR DESCRIPTION
This PR changes the logic for determining the mask state such that it is not displayed by default and only becomes available when a federal state (i.e. scenario) is selected for to which such rules apply.