### PR TITLE
Chore: introduce compound text keys

### DIFF
--- a/lib/ccl/ccl-i18n.js
+++ b/lib/ccl/ccl-i18n.js
@@ -45,8 +45,10 @@ const mapEntryToTextDescriptor = languageCode => (it, idx, arr) => {
   }
 
   const name = it.attributes.name
+  const [textType] = commentEntry.value.trim().split(':')
   const descriptor = {
-    name
+    name,
+    textType
   }
   if (it.tag === 'string') {
     descriptor.type = 'string'
@@ -71,6 +73,25 @@ const mapEntryToTextDescriptor = languageCode => (it, idx, arr) => {
   }
 }
 
+/*
+ * Resolves placeholders in text keys of text type `NOTR`.
+ * The placeholder must be in the format `${OTHER_TEXT_KEY}`.
+ */
+const resolveCompoundTexts = languageCode => (it, idx, arr) => {
+  if (it.descriptor?.textType !== 'NOTR') return it
+  const text = it.descriptor.localizedText[languageCode]
+  const newText = text.replace(/\${[^}]+}/mg, match => {
+    const textKey = match.replace('${', '').replace('}', '')
+    const textDescriptor = arr.find(it => it.descriptor?.name === textKey)
+    if (!textDescriptor) {
+      throw new Error(`Cannot resolve text key ${textKey} in compound text ${it.descriptor.name}`)
+    }
+    return textDescriptor.descriptor.localizedText[languageCode]
+  })
+  it.descriptor.localizedText[languageCode] = newText
+  return it
+}
+
 const sortByName = (a, b) => a.name < b.name ? -1 : 1
 
 const getTextDescriptorsFromXml = (xmlData, languageCode) => {
@@ -89,6 +110,7 @@ const getTextDescriptorsFromXml = (xmlData, languageCode) => {
 
   const textDescriptors = entries
     .map(mapEntryToTextDescriptor(languageCode))
+    .map(resolveCompoundTexts(languageCode))
     .filter(it => it.tag !== xmlCommentPropName)
 
   return textDescriptors


### PR DESCRIPTION
Texts components that are used multiple times can now be moved into a separate text key and referenced in a so-called compound text key. A compound text key must be of text type `NOTR` and thus will not be translated. In a compound text keys, other text keys can be included by referencing them with the syntax `${OTHER_TEXT_KEY}`. The references are replaced at build time. Text that is not a reference is preserved. This allows for example to include line breaks, e.g. `${A}\n\n${B}`.